### PR TITLE
[MSVC] Enabling SIMD functionality for VS2019

### DIFF
--- a/src/common/mkldnn_thread.hpp
+++ b/src/common/mkldnn_thread.hpp
@@ -77,8 +77,11 @@ inline void mkldnn_thr_barrier() { assert(!"no barrier in TBB"); }
 
 #endif
 
-/* MSVC still supports omp 2.0 only */
-#if defined(_MSC_VER) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+/* MSVC still supports omp 2.0 only,
+   however VS2019 also now offers SIMD functionality 
+   with the -openmp:experimental compilation switch that enables additional OpenMP features
+   not available when using the -openmp switch */
+#if defined(_MSC_VER) && (_MSC_VER < 1900) && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #   define collapse(x)
 #   define PRAGMA_OMP_SIMD(...)
 #else

--- a/src/cpu/gemm/f32/ref_gemm_f32.cpp
+++ b/src/cpu/gemm/f32/ref_gemm_f32.cpp
@@ -38,7 +38,10 @@ template <typename data_t>
 void copy_A(
         bool isTransA, int K, const data_t *A, const dim_t lda, data_t *ws) {
     for (int k = 0; k < K; k++) {
+#if !defined(_MSC_VER)
+        // Compilation with '#pragma omp simd' in this place on VS2019 to lead to fatal error C1001
         PRAGMA_OMP_SIMD()
+#endif
         for (int i = 0; i < unroll_factor<data_t>::m; i++) {
             ws[i] = isTransA ? A[i * lda + k] : A[i + k * lda];
         }


### PR DESCRIPTION
MSVC supports the OpenMP 2.0 standard, however VS 2019 also now offers SIMD functionality.
To enable '#pragma omp simd' command need to compile MSVC project with the -openmp:experimental switch that enables additional OpenMP features not available when using the -openmp switch.