### PR TITLE
Data sizes used for the offset calculation have been fixed.

### DIFF
--- a/src/common/primitive_attr.hpp
+++ b/src/common/primitive_attr.hpp
@@ -138,23 +138,24 @@ private:
 }
 
 struct mkldnn_post_ops: public mkldnn::impl::c_compatible {
+    typedef float data_t;
     struct entry_t {
         struct eltwise_t {
             mkldnn::impl::alg_kind_t alg;
-            float scale, alpha, beta;
+            data_t scale, alpha, beta;
         };
 
         mkldnn::impl::primitive_kind_t kind;
         union {
             struct {
-                float scale;
+                data_t scale;
                 mkldnn::impl::data_type_t data_type;
             } sum;
             eltwise_t eltwise;
             struct {
                 mkldnn::impl::alg_kind_t alg;
-                const float* weights_data;
-                const float* biases_data;
+                const data_t* weights_data;
+                const data_t* biases_data;
             } depthwise;
             struct {
                 int in_h;
@@ -164,22 +165,22 @@ struct mkldnn_post_ops: public mkldnn::impl::c_compatible {
                 int str_h;
                 int str_w;
                 mkldnn::impl::data_type_t in_dt;
-                const float* weights_data;
-                const float* biases_data;
+                const data_t* weights_data;
+                const data_t* biases_data;
             } dw_conv;
             struct {
                 mkldnn::impl::alg_kind_t alg;
-                const float* thresholds_data;
-                const float* output_mask_data;
+                const data_t* thresholds_data;
+                const data_t* output_mask_data;
             } binarization;
             struct {
                 mkldnn::impl::alg_kind_t alg;
-                const mkldnn::impl::shifts_t<float>* crop_low_data;
-                const mkldnn::impl::shifts_t<float>* crop_high_data;
+                const mkldnn::impl::shifts_t<data_t>* crop_low_data;
+                const mkldnn::impl::shifts_t<data_t>* crop_high_data;
                 const mkldnn::impl::scales_t* input_scale_data;
-                const mkldnn::impl::shifts_t<float>* input_shift_data;
+                const mkldnn::impl::shifts_t<data_t>* input_shift_data;
                 const mkldnn::impl::scales_t* output_scale_data;
-                const mkldnn::impl::shifts_t<float>* output_shift_data;
+                const mkldnn::impl::shifts_t<data_t>* output_shift_data;
             } quantization;
         };
 

--- a/src/cpu/gemm_bf16_convolution.cpp
+++ b/src/cpu/gemm_bf16_convolution.cpp
@@ -273,7 +273,7 @@ void gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::generate()
     if (do_bias_)
         add(reg_bias, sizeof(acc_data_t));
 
-    add(reg_oc_offset, sizeof(acc_data_t));
+    add(reg_oc_offset, sizeof(mkldnn_post_ops::data_t));
 
     dec(reg_oc_iter);
     jnz(oc_loop, T_NEAR); // oc_loop end
@@ -313,7 +313,7 @@ void gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::operator ()
                 acc_stride_in_elements * sizeof(acc_data_t);
             args.spatial_length = len;
             args.oc_work = end_oc - start_oc;
-            args.oc_offset = (start_oc + g_offset) * sizeof(acc_data_t);
+            args.oc_offset = (start_oc + g_offset) * sizeof(mkldnn_post_ops::data_t);
 
             ker_(&args);
         }

--- a/src/cpu/jit_avx512_core_bf16_1x1_conv_kernel.cpp
+++ b/src/cpu/jit_avx512_core_bf16_1x1_conv_kernel.cpp
@@ -236,8 +236,8 @@ void jit_avx512_core_bf16_1x1_conv_kernel::reduce_loop(int load_loop_blk,
                         depthwise_injectors[depthwise_inj_idx]->compute_vector_range(
                             start_idx, end_idx, reg_d_weights, reg_d_bias);
 
-                        add(reg_d_weights, jcp.oc_block * sizeof(float));
-                        add(reg_d_bias, jcp.oc_block * sizeof(float));
+                        add(reg_d_weights, jcp.oc_block * sizeof(mkldnn_post_ops::data_t));
+                        add(reg_d_bias, jcp.oc_block * sizeof(mkldnn_post_ops::data_t));
                     }
 
                     depthwise_inj_idx++;
@@ -526,7 +526,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel::generate()
             assert(!"invalid prop_kind");
         }
         sub(reg_load_loop_work, load_loop_blk * jcp.load_loop_iter_step);
-        add(reg_oc_off, load_loop_blk * jcp.oc_block * jcp.typesize_out);
+        add(reg_oc_off, load_loop_blk * jcp.oc_block * sizeof(mkldnn_post_ops::data_t));
     };
 
     const int simd_w = 16;

--- a/src/cpu/jit_avx512_core_bf16_1x1_convolution.cpp
+++ b/src/cpu/jit_avx512_core_bf16_1x1_convolution.cpp
@@ -193,7 +193,7 @@ const {
         } else
             p.bcast_data = src + data_blk_off(src_d, n, _icb, ih, iw);
 
-        p.oc_off = _ocb * jcp.oc_block * sizeof(dst_data_t);
+        p.oc_off = _ocb * jcp.oc_block * sizeof(mkldnn_post_ops::data_t);
         kernel_->jit_ker(&p);
     };
 

--- a/src/cpu/jit_avx512_core_bf16_conv_kernel.cpp
+++ b/src/cpu/jit_avx512_core_bf16_conv_kernel.cpp
@@ -147,8 +147,8 @@ void jit_avx512_core_bf16_fwd_kernel::store_output(int ur_w)
                 depthwise_injectors[depthwise_inj_idx]->compute_vector_range(
                         k*jcp.ur_w, k*jcp.ur_w + ur_w, reg_d_weights, reg_d_bias);
 
-                add(reg_d_weights, jcp.oc_block * sizeof(float));
-                add(reg_d_bias, jcp.oc_block * sizeof(float));
+                add(reg_d_weights, jcp.oc_block * sizeof(mkldnn_post_ops::data_t));
+                add(reg_d_bias, jcp.oc_block * sizeof(mkldnn_post_ops::data_t));
             }
 
             depthwise_inj_idx++;

--- a/src/cpu/jit_avx512_core_bf16_convolution.cpp
+++ b/src/cpu/jit_avx512_core_bf16_convolution.cpp
@@ -117,7 +117,7 @@ void _jit_avx512_core_bf16_convolution_fwd_t<dst_type>::execute_forward_1d()
             auto src_w = src + src_d.blk_off(n, g_icb, iw_s);
             auto wht_w = weights + wht_blk_off(weights_d, g, ocb);
 
-            par_conv.oc_off = g_oc * sizeof(dst_data_t);
+            par_conv.oc_off = g_oc * sizeof(mkldnn_post_ops::data_t);
             par_conv.src = src_w;
             par_conv.dst = dst_w;
             par_conv.filt = wht_w;
@@ -220,7 +220,7 @@ void _jit_avx512_core_bf16_convolution_fwd_t<dst_type>::execute_forward_2d()
                 auto aux_src = src_w + i_t_overflow * dilate_h * src_h_stride;
                 auto aux_wht = wht_w + i_t_overflow * wht_h_stride;
 
-                par_conv.oc_off = g_oc * sizeof(dst_data_t);
+                par_conv.oc_off = g_oc * sizeof(mkldnn_post_ops::data_t);
                 par_conv.src = aux_src;
                 par_conv.dst = dst_w;
                 par_conv.filt = aux_wht;
@@ -339,7 +339,7 @@ void _jit_avx512_core_bf16_convolution_fwd_t<dst_type>::execute_forward_3d()
                 auto aux_src = src_w + i_t_overflow * dilate_h * src_h_stride;
                 auto aux_wht = wht_w + i_t_overflow * wht_h_stride;
 
-                par_conv.oc_off = g_oc * sizeof(dst_data_t);
+                par_conv.oc_off = g_oc * sizeof(mkldnn_post_ops::data_t);
                 par_conv.src = aux_src;
                 par_conv.dst = dst_w;
                 par_conv.filt = aux_wht;


### PR DESCRIPTION
# Description

Calculation of the memory offsets in weights and biases arrays of the depthwise  operations fused into bf16 convolutions is now tied to the mkldnn_post_ops data type size (i.e. float). Using the type alias helps for better code readability and clarity.

## Bug fixes

This PR fixes issue #43567.