### PR TITLE
Reorder FP32_abcd_BF16_aBcd16b was enabled

### DIFF
--- a/src/cpu/cpu_reorder.cpp
+++ b/src/cpu/cpu_reorder.cpp
@@ -147,6 +147,7 @@ const impl_list_map_t regular_impl_list_map {
 
         DNNL_X64_ONLY(REG_REORDER_FN(uni_reorder_t))
 
+        REG_SR_BIDIR(f32, nchw, bf16, nChw16c),
         REG_SR_BIDIR(f32, any, bf16, nChw16c)
         REG_SR_BIDIR(f32, any, bf16, nCdhw16c)
 

--- a/src/cpu/simple_reorder.hpp
+++ b/src/cpu/simple_reorder.hpp
@@ -621,7 +621,8 @@ struct simple_reorder_impl<SIMPLE_REORDER_TEMPL_CALL,
 
         if (input_d.has_runtime_dims_or_strides()) return false;
 
-        return input_d.matches_tag(tag_i) && output_d.matches_tag(tag_o)
+        return input_d.mb_stride_relaxed_match(tag_i)
+                && output_d.mb_stride_relaxed_match(tag_o)
                 && input_d.data_type() == f32 && output_d.data_type() == bf16
                 && attr->has_default_values();
     }


### PR DESCRIPTION
FP32_abcd_BF16_aBcd16b reorder was enabled: addedto cpu_reorder list and changed is_applicable conditions to mb_stride_relaxed_match