### PR TITLE
Fixed compilation flags for Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -80,7 +80,10 @@ macro(enable_conditional_compilation4 target)
         target_link_libraries(${target} openvino::conditional_compilation)
         if(SELECTIVE_BUILD STREQUAL "ON")
             # After disabling a block of code, some variables might be unused.
-            target_compile_options(${target} PRIVATE -Wno-unused-variable)
+            if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
+                    OR CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$")
+                target_compile_options(${target} PRIVATE -Wno-unused-variable)
+            endif()
         endif()
     endif()
 endmacro()


### PR DESCRIPTION
# Description

I fixed CC compilation for Windows.

Fixes # (github issue)

# Checklist

## Code-change submissions

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally?
- [x] Have you formatted the code using clang-format?

### New features

- [x] Have you added relevant tests?
- [x] Have you provided motivation for adding a new feature?

### Bug fixes

- [x] Have you added relevant regression tests?
- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [x] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [x] Have you added a link to the rendered document?
