### PR TITLE
NCHW pooling perfomance fixed in accordance with v0.21

### DIFF
--- a/src/cpu/nchw_pooling.cpp
+++ b/src/cpu/nchw_pooling.cpp
@@ -88,6 +88,11 @@ void nchw_pooling_fwd_t<d_type>::execute_forward(const exec_ctx_t &ctx) const {
 
     auto ker_max = [=](data_t *d, int mb, int c, int od, int oh, int ow) {
         bool is_initialized = false;
+
+        const auto src_offset = (size_t)IW * IH * ID * C * mb + (size_t)IW * IH * ID * c;
+        const auto local_src = &src[src_offset];
+        const auto IWH = (size_t)IW * IH;
+
         for_(int kd = 0; kd < KD; ++kd)
         for_(int kh = 0; kh < KH; ++kh)
         for (int kw = 0; kw < KW; ++kw) {
@@ -99,10 +104,8 @@ void nchw_pooling_fwd_t<d_type>::execute_forward(const exec_ctx_t &ctx) const {
             if (ih < 0 || ih >= IH) continue;
             if (iw < 0 || iw >= IW) continue;
 
-            auto src_offset = (size_t)IW * IH * ID * C * mb
-                    + (size_t)IW * IH * ID * c + (size_t)IW * IH * id
-                    + (size_t)IW * ih + (size_t)iw;
-            auto s = src[src_offset];
+            const auto local_src_offset = IWH * id + (size_t)IW * ih + (size_t)iw;
+            const auto s = local_src[local_src_offset];
             if (!is_initialized) {
                 d[0] = s;
                 set_ws(mb, c, od, oh, ow, kd * KH * KW + kh * KW + kw);
@@ -141,13 +144,17 @@ void nchw_pooling_fwd_t<d_type>::execute_forward(const exec_ctx_t &ctx) const {
             num_summands = (id_end - id_start)*(ih_end - ih_start)*(iw_end - iw_start);
         if (num_summands == 0) return;
 
+        const auto src_offset = (size_t)IW * IH * ID * C * mb + (size_t)IW * IH * ID * c  + (size_t)iw_start;
+        const auto IWH = (size_t)IW * IH;
+        const size_t iw_range = iw_end - iw_start;
+
         for_(int id = id_start; id < id_end; ++id)
-        for_(int ih = ih_start; ih < ih_end; ++ih)
-        for (int iw = iw_start; iw < iw_end; ++iw) {
-            auto src_offset = (size_t)IW * IH * ID * C * mb
-                    + (size_t)IW * IH * ID * c + (size_t)IW * IH * id
-                    + (size_t)IW * ih + (size_t)iw;
-            d[0] += src[src_offset];
+        for_(int ih = ih_start; ih < ih_end; ++ih) {
+            auto local_src_offset = src_offset + IWH * id + (size_t) IW * ih;
+            const auto tmp_src = &src[local_src_offset];
+            for (size_t iw = 0; iw < iw_range; ++iw) {
+                d[0] += tmp_src[iw];
+            }
         }
 
         d[0] = out_round<data_t>((float)d[0] / num_summands);
@@ -239,6 +246,11 @@ void nchw_pooling_fwd_t<data_type::bf16>::execute_forward(
 
     auto ker_max = [=](float *d, int mb, int c, int od, int oh, int ow) {
         bool is_initialized = false;
+
+        const auto src_offset = (size_t)IW * IH * ID * C * mb + (size_t)IW * IH * ID * c;
+        const auto local_src = &bf16cvt_wsp[src_offset];
+        const auto IWH = (size_t)IW * IH;
+
         for_(int kd = 0; kd < KD; ++kd)
         for_(int kh = 0; kh < KH; ++kh)
         for (int kw = 0; kw < KW; ++kw) {
@@ -250,10 +262,8 @@ void nchw_pooling_fwd_t<data_type::bf16>::execute_forward(
             if (ih < 0 || ih >= IH) continue;
             if (iw < 0 || iw >= IW) continue;
 
-            auto src_offset = (size_t)IW * IH * ID * C * mb
-                    + (size_t)IW * IH * ID * c + (size_t)IW * IH * id
-                    + (size_t)IW * ih + (size_t)iw;
-            auto s = bf16cvt_wsp[src_offset];
+            const auto local_src_offset = IWH * id + (size_t)IW * ih + (size_t)iw;
+            const auto s = local_src[local_src_offset];
 
             if (!is_initialized) {
                 d[0] = s;
@@ -291,13 +301,17 @@ void nchw_pooling_fwd_t<data_type::bf16>::execute_forward(
             num_summands = (id_end - id_start)*(ih_end - ih_start)*(iw_end - iw_start);
         if (num_summands == 0) return;
 
+        const auto src_offset = (size_t)IW * IH * ID * C * mb + (size_t)IW * IH * ID * c + (size_t)iw_start;
+        const auto IWH = (size_t)IW * IH;
+        const size_t iw_range = iw_end - iw_start;
+
         for_(int id = id_start; id < id_end; ++id)
-        for_(int ih = ih_start; ih < ih_end; ++ih)
-        for (int iw = iw_start; iw < iw_end; ++iw) {
-            auto src_offset = (size_t)IW * IH * ID * C * mb
-                    + (size_t)IW * IH * ID * c + (size_t)IW * IH * id
-                    + (size_t)IW * ih + (size_t)iw;
-            d[0] += bf16cvt_wsp[src_offset];
+        for_(int ih = ih_start; ih < ih_end; ++ih) {
+            auto local_src_offset = src_offset + IWH * id + (size_t)IW * ih;
+            const auto tmp_src = &bf16cvt_wsp[local_src_offset];
+            for (size_t iw = 0; iw < iw_range; ++iw) {
+                d[0] += tmp_src[iw];
+            }
         }
 
         d[0] = out_round<float>((float)d[0] / num_summands);


### PR DESCRIPTION
# Description

Constant part of the source address offset calculation has been extracted from the computational loop. The same solution was used in the v0.21 version at least. This PR returns the performance level of the NCHW pooling primitive to the same level as in v0.21.