### PR TITLE
BF16 support for the softmax fork

### DIFF
--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -643,11 +643,13 @@ struct jit_softmax_conf_t {
     size_t ur_channel;
     size_t ur_inner;
     size_t outer_block;
+    size_t dt_size;
+    data_type_t dt;
 };
 
 struct jit_softmax_call_s {
-    const float *src;
-    float *dst;
+    const uint8_t* src;
+    uint8_t* dst;
 
     size_t channels;
     size_t work;

--- a/src/cpu/x64/jit_uni_fork_softmax.cpp
+++ b/src/cpu/x64/jit_uni_fork_softmax.cpp
@@ -30,8 +30,8 @@ jit_uni_fork_softmax_fwd_t<isa>::jit_uni_fork_softmax_fwd_t(const pd_t *apd)
 
 template <cpu_isa_t isa>
 status_t jit_uni_fork_softmax_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
-    auto src = CTX_IN_MEM(const float *, DNNL_ARG_SRC);
-    auto dst = CTX_OUT_MEM(float *, DNNL_ARG_DST);
+    auto src = CTX_IN_MEM(const uint8_t*, DNNL_ARG_SRC);
+    auto dst = CTX_OUT_MEM(uint8_t*, DNNL_ARG_DST);
 
     const memory_desc_wrapper data_d(pd()->src_md());
 
@@ -58,8 +58,8 @@ status_t jit_uni_fork_softmax_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
                 args.channels = jpp.channels;
                 args.work = jpp.inner_size;
                 size_t off = data_d.off_l(ou * dim);
-                args.src = src + off;
-                args.dst = dst + off;
+                args.src = src + off * jpp.dt_size;
+                args.dst = dst + off * jpp.dt_size;
 
                 (*kernel_)(&args);
 
@@ -87,8 +87,8 @@ status_t jit_uni_fork_softmax_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
                 args.channels = jpp.channels;
                 args.work = work;
                 size_t off = data_d.off_l(oub * jpp.outer_block * dim);
-                args.src = src + off;
-                args.dst = dst + off;
+                args.src = src + off * jpp.dt_size;
+                args.dst = dst + off * jpp.dt_size;
 
                 (*kernel_)(&args);
 

--- a/src/cpu/x64/jit_uni_fork_softmax.hpp
+++ b/src/cpu/x64/jit_uni_fork_softmax.hpp
@@ -62,7 +62,7 @@ struct jit_uni_fork_softmax_fwd_t : public primitive_t {
             using namespace data_type;
             bool ok = src_d == dst_d && mayiuse(isa) && is_fwd()
                       && !has_zero_dim_memory()
-                      && utils::one_of(data_type, f32)
+                      && utils::one_of(data_type, f32, bf16)
                       && attr()->has_default_values()
                       && src_d.is_dense(true)
                       && src_d.matches_one_of_tag(dat_tag) == dat_tag


### PR DESCRIPTION
# Description

Bfloat16 type support was added to the fork SoftMax primitive. 
All necessary tests have been added to the corresponding OpenVINO PR https://github.com/openvinotoolkit/openvino/pull/4279. 