### PR TITLE
Enable bf16 RNN primitives

### DIFF
--- a/src/cpu/cpu_rnn_list.cpp
+++ b/src/cpu/cpu_rnn_list.cpp
@@ -30,8 +30,8 @@ using namespace dnnl::impl::data_type;
 // clang-format off
 const pd_create_f impl_list[] = {
         CPU_INSTANCE(ref_rnn_fwd_f32_t)
-#ifdef ENABLE_UNUSED_PRIM
         CPU_INSTANCE(ref_rnn_fwd_bf16_t)
+#ifdef ENABLE_UNUSED_PRIM
         CPU_INSTANCE(ref_rnn_fwd_u8s8_t)
         CPU_INSTANCE(ref_rnn_bwd_f32_t)
         CPU_INSTANCE(ref_rnn_bwd_bf16_t)


### PR DESCRIPTION
Enable BF16 RNN primitives

Related openvino PR [4942](https://github.com/openvinotoolkit/openvino/pull/4942)