### PR TITLE
[BF16] FC layer support was added

### DIFF
--- a/src/cpu/cpu_inner_product_list.cpp
+++ b/src/cpu/cpu_inner_product_list.cpp
@@ -65,12 +65,14 @@ const pd_create_f impl_list[] = {
         CPU_INSTANCE(gemm_x8s8s32x_inner_product_fwd_t, u8, s32)
 #endif
         CPU_INSTANCE(gemm_x8s8s32x_inner_product_fwd_t, u8, f32)
+        CPU_INSTANCE(gemm_x8s8s32x_inner_product_fwd_t, u8, bf16)
         CPU_INSTANCE(gemm_x8s8s32x_inner_product_fwd_t, s8, u8)
         CPU_INSTANCE(gemm_x8s8s32x_inner_product_fwd_t, s8, s8)
 #ifdef ENABLE_UNUSED_PRIM
         CPU_INSTANCE(gemm_x8s8s32x_inner_product_fwd_t, s8, s32)
 #endif
         CPU_INSTANCE(gemm_x8s8s32x_inner_product_fwd_t, s8, f32)
+        CPU_INSTANCE(gemm_x8s8s32x_inner_product_fwd_t, s8, bf16)
 #ifdef ENABLE_UNUSED_PRIM
         CPU_INSTANCE(ref_inner_product_fwd_t, u8, s8, u8, s32)
         CPU_INSTANCE(ref_inner_product_fwd_t, u8, s8, s8, s32)

--- a/src/cpu/gemm_inner_product_utils.cpp
+++ b/src/cpu/gemm_inner_product_utils.cpp
@@ -170,6 +170,7 @@ pp_kernel_t<acc_type, dst_type> *pp_kernel_t<acc_type, dst_type>::create(
 using namespace data_type;
 template struct pp_kernel_t<f32, f32>;
 template struct pp_kernel_t<s32, f32>;
+template struct pp_kernel_t<s32, bf16>;
 template struct pp_kernel_t<s32, s32>;
 template struct pp_kernel_t<s32, s8>;
 template struct pp_kernel_t<s32, u8>;

--- a/src/cpu/gemm_x8s8s32x_inner_product.cpp
+++ b/src/cpu/gemm_x8s8s32x_inner_product.cpp
@@ -81,10 +81,12 @@ status_t gemm_x8s8s32x_inner_product_fwd_t<src_type, dst_type>::execute_forward(
 using namespace data_type;
 
 template struct gemm_x8s8s32x_inner_product_fwd_t<u8, f32>;
+template struct gemm_x8s8s32x_inner_product_fwd_t<u8, bf16>;
 template struct gemm_x8s8s32x_inner_product_fwd_t<u8, s32>;
 template struct gemm_x8s8s32x_inner_product_fwd_t<u8, s8>;
 template struct gemm_x8s8s32x_inner_product_fwd_t<u8, u8>;
 template struct gemm_x8s8s32x_inner_product_fwd_t<s8, f32>;
+template struct gemm_x8s8s32x_inner_product_fwd_t<s8, bf16>;
 template struct gemm_x8s8s32x_inner_product_fwd_t<s8, s32>;
 template struct gemm_x8s8s32x_inner_product_fwd_t<s8, s8>;
 template struct gemm_x8s8s32x_inner_product_fwd_t<s8, u8>;

--- a/src/cpu/x64/jit_gemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_gemm_inner_product_utils.cpp
@@ -888,6 +888,7 @@ pp_kernel_t<acc_type, dst_type> *jit_pp_kernel_create(size_t OC, size_t MB,
 using namespace data_type;
 INST(f32, f32);
 INST(s32, f32);
+INST(s32, bf16);
 INST(s32, s32);
 INST(s32, s8);
 INST(s32, u8);


### PR DESCRIPTION
This PR enables Fully Connected layers for INT8 input and BF16 output.

Ticket 51214