### PR TITLE
An existance of post ops flag was fixed

### DIFF
--- a/src/cpu/x64/jit_gemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_gemm_inner_product_utils.cpp
@@ -822,8 +822,7 @@ void jit_pp_kernel_t<isa, acc_type, dst_type>::generate() {
     // at least 2 blocks of mb within vlen
     bool dim_restrict = !this->runtime_oc() && !this->runtime_mb()
             && (this->OC_ <= vlen / 2) && (this->MB_ >= vlen);
-    bool supported_postops = this->do_scale_ || this->do_eltwise_
-            || this->do_sum_;
+    bool supported_postops = this->do_scale_ || (this->post_ops_.len() > 0);
 
     if (this->do_bias() && !supported_postops && dim_restrict && !utils::one_of(isa, avx2, sse41)) {
         this->mb_blk_kernel_ = true;


### PR DESCRIPTION
We have to check 'post_ops_.len()' instead of deprecated 'do_eltwise_' and 'do_sum_' flags for call function 'compute_mb_blk()', which does not support post ops.