### PR TITLE
[CPU BF16] Nspc layout enabling in FP32/BF16 convolutions

### DIFF
--- a/src/cpu/x64/gemm_bf16_convolution.cpp
+++ b/src/cpu/x64/gemm_bf16_convolution.cpp
@@ -311,7 +311,7 @@ void gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::generate() {
 template <data_type_t dst_data_type>
 void gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::operator()(
         dst_data_t *dst, const acc_data_t *acc, const acc_data_t *bias,
-        float sum_scale, size_t oc_work) {
+        float sum_scale, size_t oc_work, size_t g_offset) {
 
     ker_args args;
     args.acc = acc;
@@ -322,6 +322,7 @@ void gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::operator()(
     args.acc_stride_in_bytes = sizeof(acc_data_t);
     args.spatial_length = 1;
     args.oc_work = oc_work;
+    args.oc_offset = g_offset * sizeof(float);
     jit_generator::operator()(&args);
 }
 
@@ -496,7 +497,7 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_thr_nspc(
 
                             (*pp_ker_)(dst_arr,
                                     acc_needed ? acc_arr : (float *)dst_arr,
-                                    bia_arr, sum_scale, jcp.oc);
+                                    bia_arr, sum_scale, jcp.oc, g * jcp.oc);
                         });
             }
         }

--- a/src/cpu/x64/gemm_bf16_convolution.hpp
+++ b/src/cpu/x64/gemm_bf16_convolution.hpp
@@ -156,7 +156,7 @@ private:
         }
 
         void operator()(dst_data_t *dst, const acc_data_t *acc,
-                const acc_data_t *bias, float sum_scale, size_t oc_work);
+                const acc_data_t *bias, float sum_scale, size_t oc_work, size_t g_offset);
         void operator()(dst_data_t *dst, const acc_data_t *acc,
                 const acc_data_t *bias, size_t g_offset, size_t start_oc, float sum_scale, size_t dst_str,
                 size_t acc_str, size_t sp_len, size_t oc);

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
@@ -72,7 +72,7 @@ inline status_t init_tag(format_tag_t &tag, memory_desc_t &md,
 }
 
 inline bool is_1stconv(const jit_conv_conf_t &jcp) {
-    return one_of(jcp.ic, 1, 3);
+    return one_of(jcp.ic, 1, 2, 3);
 }
 
 inline bool is_ow_threading_on(const jit_conv_conf_t &jcp) {

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
@@ -88,7 +88,7 @@ inline bool is_1stconv(const jit_conv_conf_t &jcp) {
                     * nstl::max(jcp.typesize_in, jcp.typesize_out) * jcp.id
                     * jcp.ih * jcp.iw
             < INT_MAX;
-    return one_of(jcp.ic, 1, 3) && jcp.ngroups == 1 && no_big_offt;
+    return one_of(jcp.ic, 1, 2, 3) && jcp.ngroups == 1 && no_big_offt;
 }
 } // namespace
 

--- a/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.hpp
@@ -77,6 +77,7 @@ private:
     reg64_t iter_kh = rax;
     reg64_t reg_oi = rbx;
     reg64_t aux_reg_ch_blocks = rdx;
+    reg64_t aux_reg_blocks_offset = reg_oi;
 
     // fused convolution
     reg64_t reg_input_buffer_ptr = rdx;

--- a/src/cpu/x64/jit_avx512_core_fork_bf16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_fork_bf16_dw_conv_kernel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020 Intel Corporation
+* Copyright 2021 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -30,27 +30,37 @@ namespace x64 {
 
 using namespace Xbyak;
 
-void jit_avx512_fork_dw_conv_fwd_kernel_bf16::load_src(int ur_ch_blocks, int ur_w) {
+void jit_avx512_fork_dw_conv_fwd_kernel_bf16::load_src(int ur_ch_blocks, int ur_w, bool last_ch_block_flag) {
+    const auto dst_layout_nxc = is_dst_layout_nxc();
+    const auto ch_blk = jcp.ch_block;
+    const auto ocb_stride = dst_layout_nxc ? ch_blk : jcp.oh * jcp.ow * ch_blk;
+    const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
+
     for (int ch = 0; ch < ur_ch_blocks; ch++) {
+        const bool mask_flag = last_ch_block_flag && ch == ur_ch_blocks - 1;
         for (int ow = 0; ow < ur_w; ow++) {
             Zmm zmm_acc = get_acc_reg(ch * ur_w + ow);
+            const Zmm zmm_acc_msk
+                    = mask_flag ? zmm_acc | ktail_mask | T_z : zmm_acc;
 
             if (this->jcp.with_bias) {
-                int b_off = ch * jcp.ch_block;
-                uni_vmovups(zmm_acc, vmmword[reg_bias + b_off * sizeof(float)]);
+                int b_off = ch * ch_blk;
+                uni_vmovups(zmm_acc_msk, vmmword[reg_bias + b_off * sizeof(float)]);
             } else {
                 uni_vpxor(zmm_acc, zmm_acc, zmm_acc);
             }
             if (this->jcp.with_sum) {
-                int o_off = ch * jcp.oh * jcp.ow * jcp.ch_block
-                        + ow * jcp.ch_block;
+                int o_off = ch * ocb_stride + ow * ow_stride;
                 if (jcp.dst_dt == data_type::bf16) {
-                    vpmovzxwd(zmm_prev_dst,
+                    const Zmm zmm_prev_dst_msk = mask_flag
+                                                 ? zmm_prev_dst | ktail_mask | T_z
+                                                 : zmm_prev_dst;
+                    vpmovzxwd(zmm_prev_dst_msk,
                             vmmword[reg_output + o_off * jcp.typesize_out]);
                     vpslld(zmm_prev_dst, zmm_prev_dst, 16);
                     vaddps(zmm_acc, zmm_prev_dst);
                 } else {
-                    uni_vaddps(zmm_acc, zmm_acc,
+                    uni_vaddps(zmm_acc_msk, zmm_acc_msk,
                             vmmword[reg_output + o_off * jcp.typesize_out]);
                 }
             }
@@ -59,11 +69,18 @@ void jit_avx512_fork_dw_conv_fwd_kernel_bf16::load_src(int ur_ch_blocks, int ur_
 }
 
 void jit_avx512_fork_dw_conv_fwd_kernel_bf16::apply_filter(
-        int ur_ch_blocks, int ur_w) {
+        int ur_ch_blocks, int ur_w, bool last_ch_block_flag) {
     int ch_block = jcp.ch_block;
     int dilate_h = jcp.dilate_h + 1;
     int dilate_w = jcp.dilate_w + 1;
     int stride_w = jcp.stride_w;
+
+    const auto src_layout_nxc = is_src_layout_nxc();
+    const auto iw_stride = src_layout_nxc ? jcp.ngroups : ch_block;
+    const auto ih_stride = jcp.iw * iw_stride;
+    const auto icb_stride = src_layout_nxc
+                            ? ch_block
+                            : jcp.ih * jcp.iw * ch_block;
 
     Label iter_exit_label;
 
@@ -74,6 +91,7 @@ void jit_avx512_fork_dw_conv_fwd_kernel_bf16::apply_filter(
 
     mov(iter_kh, reg_kh);
     Label kh_label;
+    push(aux1_reg_kernel);
     L(kh_label); {
         mov(iter_kw, reg_kw);
         mov(aux1_reg_input, aux_reg_input);
@@ -82,15 +100,22 @@ void jit_avx512_fork_dw_conv_fwd_kernel_bf16::apply_filter(
         Label kw_label;
         L(kw_label); {
             for (int ch = 0; ch < ur_ch_blocks; ch++) {
+                const bool mask_flag = last_ch_block_flag && ch == ur_ch_blocks - 1;
                 int ker_off = ch * jcp.kh * jcp.kw * ch_block;
-                vpmovzxwd(zmm_ker_reg,
+                const Zmm zmm_ker_reg_msk = mask_flag
+                                            ? zmm_ker_reg | ktail_mask | T_z
+                                            : zmm_ker_reg;
+                vpmovzxwd(zmm_ker_reg_msk,
                         ptr[aux1_reg_kernel + ker_off * jcp.typesize_in]);
                 for (int ow = 0; ow < ur_w; ow++) {
+                    const Zmm zmm_src_reg_msk = mask_flag
+                                                ? zmm_src_reg | ktail_mask | T_z
+                                                : zmm_src_reg;
                     Zmm zmm_acc = get_acc_reg(ch * ur_w + ow);
-                    int inp_off = ch * jcp.ih * jcp.iw * ch_block
-                            + ow * stride_w * ch_block;
+                    int inp_off = ch * icb_stride
+                            + ow * stride_w * iw_stride;
                     /* zero-extend bf16 to packed 32-bit int */
-                    vpmovzxwd(zmm_src_reg,
+                    vpmovzxwd(zmm_src_reg_msk,
                             ptr[aux1_reg_input + inp_off * jcp.typesize_in]);
                     if (!isa_has_bf16(jcp.isa)) {
                         bf16_emu_->vdpbf16ps(zmm_acc, zmm_ker_reg, zmm_src_reg);
@@ -99,30 +124,38 @@ void jit_avx512_fork_dw_conv_fwd_kernel_bf16::apply_filter(
                     }
                 }
             }
-            add(aux1_reg_kernel, jcp.ch_block * jcp.typesize_in);
-            add(aux1_reg_input, jcp.ch_block * dilate_w * jcp.typesize_in);
+            add(aux1_reg_kernel, ch_block * jcp.typesize_in);
+            add(aux1_reg_input, iw_stride * dilate_w * jcp.typesize_in);
 
             dec(iter_kw);
             cmp(iter_kw, 0);
             jg(kw_label, T_NEAR);
         }
-        add(aux_reg_kernel, jcp.kw * jcp.ch_block * jcp.typesize_in);
-        add(aux_reg_input, jcp.iw * jcp.ch_block * dilate_h * jcp.typesize_in);
+        add(aux_reg_kernel, jcp.kw * ch_block * jcp.typesize_in);
+        add(aux_reg_input, ih_stride * dilate_h * jcp.typesize_in);
 
         dec(iter_kh);
         cmp(iter_kh, 0);
         jg(kh_label, T_NEAR);
+        pop(aux1_reg_kernel);
     }
 
     L(iter_exit_label);
 }
 
 void jit_avx512_fork_dw_conv_fwd_kernel_bf16::apply_filter_unrolled(
-        int ur_ch_blocks, int ur_w) {
+        int ur_ch_blocks, int ur_w, bool last_ch_block_flag) {
     int ch_blk = jcp.ch_block;
     int dilate_h = jcp.dilate_h + 1;
     int dilate_w = jcp.dilate_w + 1;
     int stride_w = jcp.stride_w;
+
+    const auto src_layout_nxc = is_src_layout_nxc();
+    const auto iw_stride = src_layout_nxc ? jcp.ngroups : ch_blk;
+    const auto ih_stride = jcp.iw * iw_stride;
+    const auto icb_stride = src_layout_nxc
+                            ? ch_blk
+                            : jcp.ih * jcp.iw * ch_blk;
 
     Label iter_exit_label;
 
@@ -133,17 +166,24 @@ void jit_avx512_fork_dw_conv_fwd_kernel_bf16::apply_filter_unrolled(
     Label kh_label;
     L(kh_label); {
         for (int ch = 0; ch < ur_ch_blocks; ch++) {
+            const bool mask_flag = last_ch_block_flag && ch == ur_ch_blocks - 1;
             for (int kw = 0; kw < jcp.kw; kw++) {
                 int ker_off = ch * jcp.kh * jcp.kw * ch_blk + kw * ch_blk;
+                const Zmm zmm_ker_reg_msk = mask_flag
+                                            ? zmm_ker_reg | ktail_mask | T_z
+                                            : zmm_ker_reg;
 
-                vpmovzxwd(zmm_ker_reg,
+                vpmovzxwd(zmm_ker_reg_msk,
                         ptr[aux_reg_kernel + ker_off * jcp.typesize_in]);
                 for (int ow = 0; ow < ur_w; ow++) {
+                    const Zmm zmm_src_reg_msk = mask_flag
+                                                ? zmm_src_reg | ktail_mask | T_z
+                                                : zmm_src_reg;
                     Zmm zmm_acc = get_acc_reg(ch * ur_w + ow);
-                    int inp_off = ch * jcp.ih * jcp.iw * ch_blk
-                            + ow * stride_w * ch_blk + kw * ch_blk * dilate_w;
+                    int inp_off = ch * icb_stride
+                            + ow * stride_w * iw_stride + kw * dilate_w * iw_stride;
                     /* zero-extend bf16 to packed 32-bit int */
-                    vpmovzxwd(zmm_src_reg,
+                    vpmovzxwd(zmm_src_reg_msk,
                             ptr[aux_reg_input + inp_off * jcp.typesize_in]);
                     if (!isa_has_bf16(jcp.isa)) {
                         bf16_emu_->vdpbf16ps(zmm_acc, zmm_ker_reg, zmm_src_reg);
@@ -155,7 +195,7 @@ void jit_avx512_fork_dw_conv_fwd_kernel_bf16::apply_filter_unrolled(
         }
 
         add(aux_reg_kernel, jcp.kw * ch_blk * jcp.typesize_in);
-        add(aux_reg_input, jcp.iw * ch_blk * dilate_h * jcp.typesize_in);
+        add(aux_reg_input, ih_stride * dilate_h * jcp.typesize_in);
 
         dec(iter_kh);
         cmp(iter_kh, 0);
@@ -180,11 +220,14 @@ void jit_avx512_fork_dw_conv_fwd_kernel_bf16::apply_postprocess(
             eltwise_injectors[eltwise_inj_idx]->compute_vector_range(start_idx, end_idx);
             eltwise_inj_idx++;
         } else if (post_op.is_depthwise()) {
+            push(aux_reg_blocks_offset);
+            add(aux_reg_blocks_offset, ptr[this->param1 + GET_OFF(oc_off)]); //add offset of processed blocks
+
             mov(reg_d_weights, reinterpret_cast<size_t>(post_op.depthwise.weights_data));
             mov(reg_d_bias, reinterpret_cast<size_t>(post_op.depthwise.biases_data));
 
-            add(reg_d_weights, ptr[this->param1 + GET_OFF(oc_off)]);
-            add(reg_d_bias, ptr[this->param1 + GET_OFF(oc_off)]);
+            add(reg_d_weights, aux_reg_blocks_offset);
+            add(reg_d_bias, aux_reg_blocks_offset);
 
             for (int ch = 0; ch < ur_ch_blocks; ch++) {
                 int start_idx = get_acc_reg(ur_w * ch).getIdx();
@@ -196,66 +239,196 @@ void jit_avx512_fork_dw_conv_fwd_kernel_bf16::apply_postprocess(
                 add(reg_d_weights, jcp.ch_block * sizeof(float));
                 add(reg_d_bias, jcp.ch_block * sizeof(float));
             }
+            pop(aux_reg_blocks_offset);
 
             depthwise_inj_idx++;
         }
     }
 }
 
-void jit_avx512_fork_dw_conv_fwd_kernel_bf16::store_dst(int ur_ch_blocks, int ur_w) {
-    int ch_blk = jcp.ch_block;
+void jit_avx512_fork_dw_conv_fwd_kernel_bf16::store_dst(int ur_ch_blocks, int ur_w, bool last_ch_block_flag) {
+    const auto dst_layout_nxc = is_dst_layout_nxc();
+    const auto ch_blk = jcp.ch_block;
+    const auto ocb_stride = dst_layout_nxc ? ch_blk : jcp.oh * jcp.ow * ch_blk;
+    const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
 
     if (jcp.dst_dt == data_type::bf16 && (!isa_has_bf16(jcp.isa)))
         bf16_emu_->init_vcvtneps2bf16();
 
-    for (int ch = 0; ch < ur_ch_blocks; ch++) {
+    if (dst_layout_nxc && jcp.dst_dt == data_type::bf16
+        && isa_has_bf16(jcp.isa)) {
+        for (int j = 0; j < ur_w; ++j) {
+            int n_2bf2ps = (ur_ch_blocks / 2) * 2;
+            int ch = 0;
+            for (; ch < n_2bf2ps; ch += 2) {
+                size_t aux_output_offset
+                        = (size_t)ch * ocb_stride + j * ow_stride;
+                auto addr = ptr[reg_output
+                                + aux_output_offset * jcp.typesize_out];
+                auto zmm_dst = get_acc_reg(ch * ur_w + j);
+                vcvtne2ps2bf16(
+                        zmm_dst, get_acc_reg((ch + 1) * ur_w + j), zmm_dst);
+                bool mask_flag = last_ch_block_flag && ch + 2 == ur_ch_blocks;
+                Zmm zmm_dst_msk = mask_flag ? zmm_dst | k_ch_tail_mask_extended
+                                            : zmm_dst;
+                vmovdqu16(addr, zmm_dst_msk);
+            }
+            /* Perform tail write for odd ch sizes */
+            if (ch < ur_ch_blocks) {
+                size_t aux_output_offset
+                        = (size_t) ch * ocb_stride + j * ow_stride;
+                auto addr = ptr[reg_output
+                                + aux_output_offset * jcp.typesize_out];
+                auto zmm_dst = get_acc_reg(ch * ur_w + j);
+                auto ymm_dst = Ymm(zmm_dst.getIdx());
+                vcvtneps2bf16(ymm_dst, zmm_dst);
+                Ymm ymm_dst_msk = last_ch_block_flag ? ymm_dst | ktail_mask : ymm_dst;
+                vmovdqu16(addr, ymm_dst_msk);
+            }
+        }
+    } else {
+        // also used for case when dst_layout_nxc && dst.dt == f32
         if (jcp.dst_dt == data_type::f32) {
-            for (int ow = 0; ow < ur_w; ow++) {
-                int o_off = ch * jcp.oh * jcp.ow * ch_blk + ow * ch_blk;
-                Zmm zmm_dst = get_acc_reg(ch * ur_w + ow);
-                uni_vmovups(vmmword[reg_output + o_off * jcp.typesize_out],
-                        zmm_dst);
+            for (int ch = 0; ch < ur_ch_blocks; ch++) {
+                bool mask_flag = last_ch_block_flag && ch == ur_ch_blocks - 1;
+                for (int ow = 0; ow < ur_w; ow++) {
+                    int o_off = ch * ocb_stride + ow * ow_stride;
+                    Zmm zmm_dst = get_acc_reg(ch * ur_w + ow);
+                    Zmm zmm_dst_msk = mask_flag ? zmm_dst | ktail_mask : zmm_dst;
+                    vmovups(vmmword[reg_output + o_off * jcp.typesize_out],
+                            zmm_dst_msk);
+                }
             }
         } else if (jcp.dst_dt == data_type::bf16) {
-            if (isa_has_bf16(jcp.isa)) {
-                int n_2bf2ps = (ur_w / 2) * 2;
-                int j = 0;
-                for (; j < n_2bf2ps; j += 2) {
-                    size_t aux_output_offset
-                            = ((size_t)ch * jcp.oh * jcp.ow + j) * jcp.ch_block;
-                    auto addr = ptr[reg_output
-                            + aux_output_offset * jcp.typesize_out];
-                    auto zmm_dst = get_acc_reg(ch * ur_w + j);
-                    vcvtne2ps2bf16(zmm_dst, get_acc_reg(ch * ur_w + j + 1),
-                            get_acc_reg(ch * ur_w + j));
-                    vmovups(addr, zmm_dst);
-                }
-                /* Perform tail write for odd ur_w sizes */
-                if (j < ur_w) {
-                    size_t aux_output_offset
-                            = ((size_t)ch * jcp.oh * jcp.ow + j) * jcp.ch_block;
-                    auto addr = ptr[reg_output
-                            + aux_output_offset * jcp.typesize_out];
-                    auto zmm_dst = get_acc_reg(ch * ur_w + j);
-                    auto ymm_dst = Ymm(zmm_dst.getIdx());
-                    vcvtneps2bf16(ymm_dst, zmm_dst);
-                    vmovups(addr, ymm_dst);
+            if (isa_has_bf16(jcp.isa)) { // !dst_layout_nxc()
+                assert(jcp.ngroups % jcp.ch_block == 0);
+                for (int ch = 0; ch < ur_ch_blocks; ch++) {
+                    int n_2bf2ps = (ur_w / 2) * 2;
+                    int j = 0;
+                    for (; j < n_2bf2ps; j += 2) {
+                        size_t aux_output_offset
+                                = (size_t)ch * ocb_stride + j * ow_stride;
+                        auto addr = ptr[reg_output
+                                        + aux_output_offset * jcp.typesize_out];
+                        auto zmm_dst = get_acc_reg(ch * ur_w + j);
+                        vcvtne2ps2bf16(zmm_dst, get_acc_reg(ch * ur_w + j + 1),
+                                       get_acc_reg(ch * ur_w + j));
+                        vmovups(addr, zmm_dst);
+                    }
+                    /* Perform tail write for odd ur_w sizes */
+                    if (j < ur_w) {
+                        size_t aux_output_offset
+                                = (size_t)ch * ocb_stride + j * ow_stride;
+                        auto addr = ptr[reg_output
+                                        + aux_output_offset * jcp.typesize_out];
+                        auto zmm_dst = get_acc_reg(ch * ur_w + j);
+                        auto ymm_dst = Ymm(zmm_dst.getIdx());
+                        vcvtneps2bf16(ymm_dst, zmm_dst);
+                        vmovups(addr, ymm_dst);
+                    }
                 }
             } else {
-                for (int ow = 0; ow < ur_w; ow++) {
-                    int o_off = ch * jcp.oh * jcp.ow * ch_blk + ow * ch_blk;
-                    Zmm zmm_dst = get_acc_reg(ch * ur_w + ow);
+                for (int ch = 0; ch < ur_ch_blocks; ch++) {
+                    bool mask_flag = last_ch_block_flag && ch == ur_ch_blocks - 1;
+                    for (int ow = 0; ow < ur_w; ow++) {
+                        int o_off = ch * ocb_stride + ow * ow_stride;
+                        Zmm zmm_dst = get_acc_reg(ch * ur_w + ow);
 
-                    /* down-convert f32 output to bf16 */
-                    auto ymm_dst = Ymm(zmm_dst.getIdx());
-                    bf16_emu_->vcvtneps2bf16(ymm_dst, zmm_dst);
+                        /* down-convert f32 output to bf16 */
+                        auto ymm_dst = Ymm(zmm_dst.getIdx());
+                        bf16_emu_->vcvtneps2bf16(ymm_dst, zmm_dst);
 
-                    uni_vmovups(ptr[reg_output + o_off * jcp.typesize_out],
-                            ymm_dst);
+                        Ymm ymm_dst_msk = mask_flag ? ymm_dst | ktail_mask : ymm_dst;
+                        vmovdqu16(ptr[reg_output + o_off * jcp.typesize_out], ymm_dst_msk);
+                    }
                 }
             }
         } else
             assert(!"unsupported destination type");
+    }
+}
+
+void jit_avx512_fork_dw_conv_fwd_kernel_bf16::compute_loop(int ur_w, int ur_ch_blocks) {
+    const bool ch_loop = ur_ch_blocks > jcp.nb_ch_blocking;
+    // ch_loop currently happen only when data layout is nxc. The strides are
+    // calculated for this layout only.
+    const size_t wei_ch_stride = (size_t)jcp.nb_ch_blocking * jcp.kd * jcp.kh * jcp.kw
+                                 * jcp.ch_block * jcp.typesize_in;
+    const size_t inp_ch_stride
+            = (size_t)jcp.nb_ch_blocking * jcp.ch_block * jcp.typesize_in;
+    const size_t out_ch_stride
+            = (size_t)jcp.nb_ch_blocking * jcp.ch_block * jcp.typesize_out;
+    const size_t bias_stride
+            = (size_t)jcp.nb_ch_blocking * jcp.ch_block * sizeof(float);
+
+    auto compute = [&](int ur_ch_blocks, bool last_ch_block_flag = false) {
+        mov(aux_reg_input, reg_input);
+        mov(aux_reg_kernel, reg_kernel);
+
+        load_src(ur_ch_blocks, ur_w, last_ch_block_flag);
+        if (ur_w == 1) {
+            apply_filter(ur_ch_blocks, ur_w, last_ch_block_flag);
+        } else {
+            apply_filter_unrolled(ur_ch_blocks, ur_w, last_ch_block_flag);
+        }
+        apply_postprocess(ur_ch_blocks, ur_w);
+        store_dst(ur_ch_blocks, ur_w, last_ch_block_flag);
+    };
+
+    const bool masked_ch_block_tail = jcp.oc % jcp.ch_block != 0;
+
+    xor_(aux_reg_blocks_offset, aux_reg_blocks_offset);
+
+    if (ch_loop) {
+        Label ch_loop_label, ch_tail_label, skip_ch_tail_label;
+        const int nb_ch = jcp.oc / jcp.ch_block;
+        const int nb_ch_blocking_tail = jcp.nb_ch - utils::rnd_dn(nb_ch, jcp.nb_ch_blocking);
+        const int ch_step = jcp.nb_ch_blocking * jcp.ch_block;
+
+        push(aux_reg_ch_blocks);
+        mov(aux_reg_ch_blocks, reg_ch_blocks);
+        push(reg_kernel);
+        push(reg_input);
+        push(reg_output);
+        if (jcp.with_bias) push(reg_bias);
+
+        if (nb_ch >= jcp.nb_ch_blocking) {
+            if (nb_ch_blocking_tail) {
+                cmp(aux_reg_ch_blocks, ch_step);
+                jl(ch_tail_label, T_NEAR);
+            }
+
+            L(ch_loop_label);
+            {
+                compute(jcp.nb_ch_blocking);
+                add(reg_kernel, wei_ch_stride);
+                add(reg_input, inp_ch_stride);
+                add(reg_output, out_ch_stride);
+                if (jcp.with_bias) add(reg_bias, bias_stride);
+                sub(aux_reg_ch_blocks, ch_step);
+                add(aux_reg_blocks_offset, ch_step * sizeof(float)); //add initial offset of processed blocks
+                cmp(aux_reg_ch_blocks, ch_step);
+                jge(ch_loop_label, T_NEAR);
+            }
+        }
+
+        if (nb_ch_blocking_tail) {
+            // ch work range [1, jcp.nb_ch_blocking * ch_block)
+            L(ch_tail_label);
+            cmp(aux_reg_ch_blocks, 0);
+            jle(skip_ch_tail_label, T_NEAR);
+            compute(nb_ch_blocking_tail, masked_ch_block_tail);
+            L(skip_ch_tail_label);
+        }
+
+        if (jcp.with_bias) pop(reg_bias);
+        pop(reg_output);
+        pop(reg_input);
+        pop(reg_kernel);
+        pop(aux_reg_ch_blocks);
+
+    } else {
+        compute(ur_ch_blocks, masked_ch_block_tail);
     }
 }
 
@@ -265,22 +438,22 @@ void jit_avx512_fork_dw_conv_fwd_kernel_bf16::loop_ow(int ur_ch_blocks) {
     Label tail_w_label;
     Label exit_label;
 
+    const auto src_layout_nxc = is_src_layout_nxc();
+    const auto dat_c_stride = src_layout_nxc ? jcp.ngroups : jcp.ch_block;
+
     L(unrolled_w_label); {
         int ur_w = jcp.ur_w;
+
+        size_t inp_shift = (size_t)jcp.typesize_in * ur_w * jcp.stride_w * dat_c_stride;
+        size_t out_shift = (size_t)jcp.typesize_out * ur_w * dat_c_stride;
 
         cmp(reg_ur_w, ur_w);
         jl(tail_w_label, T_NEAR);
 
-        mov(aux_reg_input, reg_input);
-        mov(aux_reg_kernel, reg_kernel);
+        compute_loop(ur_w, ur_ch_blocks);
 
-        load_src(ur_ch_blocks, ur_w);
-        apply_filter_unrolled(ur_ch_blocks, ur_w);
-        apply_postprocess(ur_ch_blocks, ur_w);
-        store_dst(ur_ch_blocks, ur_w);
-
-        add(reg_input, jcp.typesize_in * ur_w * jcp.ch_block * jcp.stride_w);
-        add(reg_output, jcp.typesize_out * ur_w * jcp.ch_block);
+        add(reg_input, inp_shift);
+        add(reg_output, out_shift);
 
         sub(reg_ur_w, ur_w);
         jmp(unrolled_w_label);
@@ -289,19 +462,16 @@ void jit_avx512_fork_dw_conv_fwd_kernel_bf16::loop_ow(int ur_ch_blocks) {
     L(tail_w_label); {
         int ur_w = 1;
 
+        size_t inp_shift = (size_t)jcp.typesize_in * ur_w * jcp.stride_w * dat_c_stride;
+        size_t out_shift = (size_t)jcp.typesize_out * ur_w * dat_c_stride;
+
         cmp(reg_ur_w, ur_w);
         jl(exit_label, T_NEAR);
 
-        mov(aux_reg_input, reg_input);
-        mov(aux_reg_kernel, reg_kernel);
+        compute_loop(ur_w, ur_ch_blocks);
 
-        load_src(ur_ch_blocks, ur_w);
-        apply_filter(ur_ch_blocks, ur_w);
-        apply_postprocess(ur_ch_blocks, ur_w);
-        store_dst(ur_ch_blocks, ur_w);
-
-        add(reg_input, jcp.typesize_in * ur_w * jcp.ch_block * jcp.stride_w);
-        add(reg_output, jcp.typesize_out * ur_w * jcp.ch_block);
+        add(reg_input, inp_shift);
+        add(reg_output, out_shift);
 
         sub(reg_ur_w, ur_w);
         jmp(tail_w_label);
@@ -336,29 +506,62 @@ void jit_avx512_fork_dw_conv_fwd_kernel_bf16::generate() {
         mov(reg_bias, ptr[this->param1 + GET_OFF(bias)]);
     mov(reg_kh, ptr[this->param1 + GET_OFF(kh_padding)]);
     mov(reg_kw, ptr[this->param1 + GET_OFF(kw_padding)]);
-    mov(reg_ch_blocks, ptr[this->param1 + GET_OFF(ch_blocks)]);
+    mov(reg_ch_blocks, ptr[this->param1 + GET_OFF(load_work)]);
     mov(reg_ur_w, ptr[this->param1 + GET_OFF(ur_w)]);
 
     Label ch_blocks_tail_label;
     Label exit_label;
 
     int ch_blocks_tail = jcp.nb_ch % jcp.nb_ch_blocking;
+    const auto oc_tail = jcp.oc_without_padding % jcp.ch_block;
+    if (oc_tail != 0) {
+        // Note: is_src_layout_nxc() == true, otherwise channels are padded
+        // Prepare masks for tailing
+        const int oc_tail_shift
+                = jcp.ch_block - jcp.oc_without_padding % jcp.ch_block;
+        static constexpr auto zmm_16b_mask = ((1 << 16) - 1);
 
-    cmp(reg_ch_blocks, jcp.nb_ch_blocking);
-    jne(ch_blocks_tail ? ch_blocks_tail_label : exit_label, T_NEAR);
+        // To account for special store optimization, where two oc_blocks are
+        // combined with one single write, extend the mask for 32 bits
+        // (i.e. 32 bfloat16 elements)
+        const bool need_extended_mask = jcp.dst_dt == data_type::bf16
+                                        && isa_has_bf16(jcp.isa) && jcp.nb_ch_blocking > 1;
+        if (need_extended_mask)
+            kxnord(k_ch_tail_mask_extended, k_ch_tail_mask_extended,
+                   k_ch_tail_mask_extended);
 
-    loop_ow(jcp.nb_ch_blocking); // channel main loop
-
-    if (ch_blocks_tail) {
-        L(ch_blocks_tail_label);
-
-        cmp(reg_ch_blocks, ch_blocks_tail);
-        jne(exit_label, T_NEAR);
-
-        loop_ow(ch_blocks_tail); // channel tail loop
+        Label done;
+        mov(reg_tail, ptr[this->param1 + GET_OFF(load_work)]);
+        cmp(reg_tail, jcp.nb_ch_blocking * jcp.ch_block);
+        je(done, T_NEAR);
+        Reg32 reg_tail_32 = reg_tail.cvt32();
+        mov(reg_tail_32, zmm_16b_mask >> oc_tail_shift);
+        kmovw(k_oc_tail_mask, reg_tail_32);
+        if (need_extended_mask) {
+            auto zmm_32b_mask = (1 << (oc_tail + jcp.ch_block)) - 1;
+            mov(reg_tail_32, zmm_32b_mask);
+            kmovd(k_ch_tail_mask_extended, reg_tail_32);
+        }
+        L(done);
     }
 
-    L(exit_label);
+    if (is_src_layout_nxc()) {
+        loop_ow(jcp.nb_ch);
+    } else {
+        cmp(reg_ch_blocks, (jcp.nb_ch_blocking - 1) * jcp.ch_block);
+        jle(ch_blocks_tail ? ch_blocks_tail_label : exit_label, T_NEAR);
+
+        loop_ow(jcp.nb_ch_blocking); // channel main loop
+
+        if (ch_blocks_tail) {
+            jmp(exit_label, T_NEAR);
+            L(ch_blocks_tail_label);
+
+            loop_ow(ch_blocks_tail); // channel tail loop
+        }
+
+        L(exit_label);
+    }
 
     this->postamble();
 

--- a/src/cpu/x64/jit_avx512_core_fork_bf16_dw_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_fork_bf16_dw_conv_kernel.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020 Intel Corporation
+* Copyright 2021 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -60,6 +60,7 @@ struct jit_avx512_fork_dw_conv_fwd_kernel_bf16 : public jit_generator {
 
 private:
     using reg64_t = const Xbyak::Reg64;
+    using mask_t = const Xbyak::Opmask;
     const Xbyak::AddressFrame &vmmword = zword;
 
     const int acc_idx_start = 2;
@@ -71,7 +72,7 @@ private:
     reg64_t aux1_reg_input = r10;
     reg64_t reg_kernel = r11;
     reg64_t aux_reg_kernel = r12;
-    reg64_t aux1_reg_kernel = r13;
+    reg64_t reg_ch_blocks = r13;
     reg64_t reg_output = r14;
     reg64_t reg_bias = r15;
     reg64_t reg_kh = rax;
@@ -79,10 +80,17 @@ private:
     reg64_t iter_kh = rdx;
     reg64_t iter_kw = rsi;
     reg64_t reg_ur_w = rbp;
-    reg64_t reg_ch_blocks = aux1_reg_input;
+    reg64_t reg_tail = abi_not_param1;
+    reg64_t aux1_reg_kernel = reg_ch_blocks;
     reg64_t imm_addr64 = aux1_reg_input;
     reg64_t reg_d_weights = imm_addr64;
     reg64_t reg_d_bias = iter_kh;
+    reg64_t aux_reg_ch_blocks = reg_ur_w;
+    reg64_t aux_reg_blocks_offset = reg_tail;
+
+    mask_t k_oc_tail_mask = Xbyak::Opmask(2);
+    mask_t ktail_mask = k_oc_tail_mask;
+    mask_t k_ch_tail_mask_extended = Xbyak::Opmask(3);
 
     Xbyak::Zmm zmm_ker_reg = Xbyak::Zmm(0);
     Xbyak::Zmm zmm_src_reg = Xbyak::Zmm(1);
@@ -101,11 +109,22 @@ private:
         return Xbyak::Zmm(idx + acc_idx_start);
     }
 
-    inline void load_src(int ur_ch_blocks, int ur_w);
-    inline void apply_filter(int ur_ch_blocks, int ur_w);
-    inline void apply_filter_unrolled(int ur_ch_blocks, int ur_w);
+    inline bool is_src_layout_nxc() {
+        return utils::one_of(jcp.src_tag, format_tag::ndhwc, format_tag::nhwc,
+                             format_tag::nwc);
+    }
+
+    inline bool is_dst_layout_nxc() {
+        return utils::one_of(jcp.dst_tag, format_tag::ndhwc, format_tag::nhwc,
+                             format_tag::nwc);
+    }
+
+    inline void load_src(int ur_ch_blocks, int ur_w, bool last_ch_block_flag);
+    inline void compute_loop(int ur_w, int ur_ch_blocks);
+    inline void apply_filter(int ur_ch_blocks, int ur_w, bool last_ch_block_flag);
+    inline void apply_filter_unrolled(int ur_ch_blocks, int ur_w, bool last_ch_block_flag);
     inline void apply_postprocess(int ur_ch_blocks, int ur_w);
-    inline void store_dst(int ur_ch_blocks, int ur_w);
+    inline void store_dst(int ur_ch_blocks, int ur_w, bool last_ch_block_flag);
     inline void loop_ow(int ur_ch_blocks);
 
     nstl::vector<jit_uni_eltwise_injector_f32<avx512_common>*> eltwise_injectors;

--- a/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
@@ -634,8 +634,11 @@ status_t jit_sse41_1x1_conv_kernel_f32::init_conf(jit_1x1_conv_conf_t &jcp,
 
     const int simd_w = 4;
 
-    jcp.oc = rnd_up(jcp.oc, simd_w*2);
-    jcp.ic = rnd_up(jcp.ic, simd_w*2);
+    bool ok_to_pad_channels = true && !is_data_layout_nxc && jcp.ngroups == 1;
+    if (ok_to_pad_channels) {
+        jcp.oc = rnd_up(jcp.oc, simd_w*2);
+        jcp.ic = rnd_up(jcp.ic, simd_w*2);
+    }
 
     jcp.ic_block = jcp.oc_block = simd_w * 2;
 

--- a/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
@@ -474,7 +474,7 @@ status_t jit_sse41_conv_fwd_kernel_f32::init_conf(jit_conv_conf_t &jcp,
     jcp.with_eltwise = eltwise_ind != -1;
     if (jcp.with_eltwise) jcp.eltwise = p.entry_[eltwise_ind].eltwise;
 
-    const bool flat = jcp.ic == 3 || jcp.ic == 1;
+    const bool flat = one_of(jcp.ic, 1, 2, 3);
     const bool mimo = !flat;
 
     bool args_ok = true
@@ -494,7 +494,7 @@ status_t jit_sse41_conv_fwd_kernel_f32::init_conf(jit_conv_conf_t &jcp,
             && jcp.oc <= dst_d.padded_dims()[1];
     if (!args_ok) return status::unimplemented;
 
-    bool ok_to_pad_channels = true && jcp.ngroups == 1;
+    bool ok_to_pad_channels = true && !is_data_layout_nxc && jcp.ngroups == 1;
 
     const int simd_w = 8; // 2 SSE vectors processing at once
     if (ok_to_pad_channels) {

--- a/src/cpu/x64/jit_sse41_convolution.hpp
+++ b/src/cpu/x64/jit_sse41_convolution.hpp
@@ -69,7 +69,7 @@ struct jit_sse41_convolution_fwd_t : public primitive_t {
         bool set_default_formats() {
             using namespace format_tag;
 
-            const bool flat = IC() == 3 || IC() == 1;
+            const bool flat = utils::one_of(IC(), 1, 2, 3);
             auto src_tag = flat
                     ? utils::pick(ndims() - 3, ncw, nchw, ncdhw)
                     : utils::pick(ndims() - 3, nCw8c, nChw8c, nCdhw8c);

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_f32.hpp
@@ -84,6 +84,8 @@ private:
     reg64_t reg_d_weights = aux_reg_input_buffer_ptr;
     reg64_t reg_d_bias = iter_kh;
 
+    reg64_t aux_reg_blocks_offset = abi_not_param1;
+
     Vmm vmm_d_weights = Vmm(0);
     Vmm vmm_d_bias = Vmm(1);
 

--- a/src/cpu/x64/jit_uni_fork_dw_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_uni_fork_dw_conv_kernel_f32.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020 Intel Corporation
+* Copyright 2021 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -35,26 +35,67 @@ using namespace dnnl::impl::utils;
 
 using namespace Xbyak;
 
+static bool check_if_tail_load(const bool is_ch_tail, const int c_tail, const int ch,
+                               const int ur_ch_blocks, const int vlen, const int i) {
+    return is_ch_tail && (ch + 1 == ur_ch_blocks) && ((i + 1) * vlen > c_tail);
+}
+
+
 template <cpu_isa_t isa>
-void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::load_src(int ur_ch_blocks, int ur_w) {
-    int repeats = isa == sse41 ? 2 : 1;
+void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::load_src(int ur_ch_blocks, int ur_w, bool is_ch_tail) {
+    const auto dst_layout_nxc = is_dst_layout_nxc();
+    const auto ch_blk = jcp.ch_block;
+    const auto ocb_stride = dst_layout_nxc ? ch_blk : jcp.od * jcp.oh * jcp.ow * ch_blk;
+    const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
+    const int vlen_numbers = cpu_isa_traits<isa>::vlen / sizeof(float);
+    const int c_tail = jcp.oc % jcp.ch_block;
+
+    int repeats = jcp.ch_block / vlen_numbers;
+    assert((repeats == 1) || (repeats == 2 && isa == sse41));
     for (int i = 0; i < repeats; i++) {
         for (int ch = 0; ch < ur_ch_blocks; ch++) {
+            const bool is_tail_load = check_if_tail_load(
+                    is_ch_tail, c_tail, ch, ur_ch_blocks, vlen_numbers, i);
+            if ((ch + 1 == ur_ch_blocks) && is_ch_tail && c_tail <= i * vlen_numbers)
+                continue;
             for (int ow = 0; ow < ur_w; ow++) {
                 Vmm vmm_acc = get_acc_reg(i*ur_ch_blocks*ur_w + ch*ur_w + ow);
 
-                int b_off = ch*jcp.ch_block + i*4;
-                if (this->jcp.with_bias)
-                    uni_vmovups(vmm_acc,
-                        vmmword[reg_bias + b_off*sizeof(float)]);
-                else
+                int b_off = ch*ch_blk + i*vlen_numbers;
+                if (this->jcp.with_bias) {
+                    if (is_tail_load) {
+                        load_tail(vmm_acc, reg_bias, b_off * sizeof(float),
+                                  (c_tail - i*vlen_numbers) * sizeof(float));
+                    } else {
+                        uni_vmovups(vmm_acc,
+                                    vmmword[reg_bias + b_off * sizeof(float)]);
+                    }
+                } else {
                     uni_vpxor(vmm_acc, vmm_acc, vmm_acc);
+                }
 
-                int o_off = ch*jcp.od*jcp.oh*jcp.ow*jcp.ch_block
-                    + ow*jcp.ch_block + i*4;
-                if (this->jcp.with_sum)
-                    uni_vaddps(vmm_acc, vmm_acc,
-                        vmmword[reg_output + o_off*sizeof(float)]);
+                int o_off = ch*ocb_stride
+                    + ow*ow_stride + i*vlen_numbers;
+                if (this->jcp.with_sum) {
+                    if (is_tail_load) {
+                        if (this->jcp.with_bias) {
+                            // using ker_vmm as vmm_tmp as it is safe to do so.
+                            auto vmm_tmp = get_ker_reg(0);
+                            add_tail_from_mem(vmm_acc, vmm_tmp, reg_output,
+                                              o_off * sizeof(float),
+                                              (c_tail - i*vlen_numbers) * sizeof(float));
+                        } else {
+                            // nothing to add, just load dst.
+                            load_tail(vmm_acc, reg_output,
+                                      o_off * sizeof(float),
+                                      c_tail * sizeof(float));
+                        }
+                    } else {
+                        // blocked layout has dst padded, so no tail handling.
+                        uni_vaddps(vmm_acc, vmm_acc,
+                                   vmmword[reg_output + o_off*sizeof(float)]);
+                    }
+                }
             }
         }
     }
@@ -62,17 +103,25 @@ void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::load_src(int ur_ch_blocks, int ur
 
 template <cpu_isa_t isa>
 void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::apply_filter(
-        int ur_ch_blocks, int ur_w) {
+        int ur_ch_blocks, int ur_w, bool is_ch_tail) {
     int ch_blk = jcp.ch_block;
     int dilate_d = jcp.dilate_d + 1;
     int dilate_h = jcp.dilate_h + 1;
     int dilate_w = jcp.dilate_w + 1;
     int stride_w = jcp.stride_w;
 
+    const auto src_layout_nxc = is_src_layout_nxc();
+    const auto iw_stride = src_layout_nxc ? jcp.ngroups : ch_blk;
+    const auto ih_stride = jcp.iw * iw_stride;
+    const auto icb_stride = src_layout_nxc
+                            ? ch_blk
+                            : jcp.id * jcp.ih * jcp.iw * ch_blk;
+
     Label iter_exit_label;
     Label kd_label, iter_d_exit_label;
 
     if (jcp.ndims == 5) {
+        push(reg_kd);
         mov(reg_kd, ptr[this->param1 + GET_OFF(kd_padding)]);
         cmp(reg_kd, 0);
         je(iter_d_exit_label, T_NEAR);
@@ -94,6 +143,7 @@ void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::apply_filter(
 
     mov(iter_kh, reg_kh);
     Label kh_label;
+    push(aux1_reg_kernel);
     L(kh_label); {
         mov(iter_kw, reg_kw);
         mov(aux1_reg_input, aux_reg_input);
@@ -101,20 +151,34 @@ void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::apply_filter(
 
         Label kw_label;
         L(kw_label); {
-            int repeats = isa == sse41 ? 2 : 1;
+            const int vlen_numbers = cpu_isa_traits<isa>::vlen / sizeof(float);
+            const int c_tail = jcp.oc % jcp.ch_block;
+            int repeats = jcp.ch_block / vlen_numbers;
+            assert((repeats == 1) || (repeats == 2 && isa == sse41));
             for (int i = 0; i < repeats; i++) {
                 for (int ch = 0; ch < ur_ch_blocks; ch++) {
-                    int ker_off = ch*jcp.kd*jcp.kh*jcp.kw*ch_blk + i*4;
+                    const bool is_tail_load = check_if_tail_load(
+                            is_ch_tail, c_tail, ch, ur_ch_blocks, vlen_numbers, i);
+                    if ((ch + 1 == ur_ch_blocks) && is_ch_tail
+                            && c_tail <= i*vlen_numbers)
+                        continue;
+                    int ker_off = ch*jcp.kd*jcp.kh*jcp.kw*ch_blk + i*vlen_numbers;
                     Vmm vmm_ker = get_ker_reg(0);
                     uni_vmovups(vmm_ker, ptr[aux1_reg_kernel
                         + ker_off*sizeof(float)]);
 
                     for (int ow = 0; ow < ur_w; ow++) {
-                        int inp_off = ch*jcp.id*jcp.ih*jcp.iw*ch_blk
-                            + ow*stride_w*ch_blk + i*4;
+                        int inp_off = ch*icb_stride
+                            + ow*stride_w*iw_stride + i*vlen_numbers;
                         Vmm vmm_src = get_src_reg(0);
-                        uni_vmovups(vmm_src, ptr[aux1_reg_input
-                            + inp_off*sizeof(float)]);
+                        if (is_tail_load) {
+                            load_tail(vmm_src, aux1_reg_input,
+                                      inp_off * sizeof(float),
+                                      (c_tail - i*vlen_numbers) * sizeof(float));
+                        } else {
+                            uni_vmovups(vmm_src,
+                                        ptr[aux1_reg_input + inp_off*sizeof(float)]);
+                        }
 
                         Vmm vmm_acc = get_acc_reg(i*ur_ch_blocks*ur_w
                             + ch*ur_w + ow);
@@ -123,25 +187,26 @@ void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::apply_filter(
                 }
             }
             add(aux1_reg_kernel, ch_blk*sizeof(float));
-            add(aux1_reg_input, ch_blk*dilate_w*sizeof(float));
+            add(aux1_reg_input, iw_stride*dilate_w*sizeof(float));
 
             dec(iter_kw);
             cmp(iter_kw, 0);
             jg(kw_label, T_NEAR);
         }
         add(aux_reg_kernel, jcp.kw*ch_blk*sizeof(float));
-        add(aux_reg_input, jcp.iw*ch_blk*dilate_h*sizeof(float));
+        add(aux_reg_input, ih_stride*dilate_h*sizeof(float));
 
         dec(iter_kh);
         cmp(iter_kh, 0);
         jg(kh_label, T_NEAR);
+        pop(aux1_reg_kernel);
     }
 
     L(iter_exit_label);
 
     if (jcp.ndims == 5) {
         add(aux_reg_ker_d, jcp.kh*jcp.kw*ch_blk*sizeof(float));
-        add(aux_reg_inp_d, jcp.ih*dilate_d*jcp.iw*ch_blk*sizeof(float));
+        add(aux_reg_inp_d, jcp.ih*dilate_d*ih_stride*sizeof(float));
 
         mov(aux_reg_input, aux_reg_inp_d);
         mov(aux_reg_kernel, aux_reg_ker_d);
@@ -154,22 +219,31 @@ void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::apply_filter(
         pop(reg_input);
 
         L(iter_d_exit_label);
+        pop(reg_kd);
     }
 }
 
 template <cpu_isa_t isa>
 void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::apply_filter_unrolled(
-        int ur_ch_blocks, int ur_w) {
+        int ur_ch_blocks, int ur_w, bool is_ch_tail) {
     int ch_blk = jcp.ch_block;
     int dilate_d = jcp.dilate_d + 1;
     int dilate_h = jcp.dilate_h + 1;
     int dilate_w = jcp.dilate_w + 1;
     int stride_w = jcp.stride_w;
 
+    const auto src_layout_nxc = is_src_layout_nxc();
+    const auto iw_stride = src_layout_nxc ? jcp.ngroups : ch_blk;
+    const auto ih_stride = jcp.iw * iw_stride;
+    const auto icb_stride = src_layout_nxc
+                            ? ch_blk
+                            : jcp.id * jcp.ih * jcp.iw * ch_blk;
+
     Label iter_exit_label;
     Label kd_label, iter_d_exit_label;
 
     if (jcp.ndims == 5) {
+        push(reg_kd);
         mov(reg_kd, ptr[this->param1 + GET_OFF(kd_padding)]);
         cmp(reg_kd, 0);
         je(iter_d_exit_label, T_NEAR);
@@ -190,23 +264,37 @@ void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::apply_filter_unrolled(
     mov(iter_kh, reg_kh);
     Label kh_label;
     L(kh_label); {
-        int repeats = isa == sse41 ? 2 : 1;
+        const int vlen_numbers = cpu_isa_traits<isa>::vlen / sizeof(float);
+        const int c_tail = jcp.oc % jcp.ch_block;
+        int repeats = jcp.ch_block / vlen_numbers;
+        assert((repeats == 1) || (repeats == 2 && isa == sse41));
         for (int i = 0; i < repeats; i++) {
             for (int ch = 0; ch < ur_ch_blocks; ch++) {
+                const bool is_tail_load = check_if_tail_load(
+                        is_ch_tail, c_tail, ch, ur_ch_blocks, vlen_numbers, i);
+                if ((ch + 1 == ur_ch_blocks) && is_ch_tail
+                    && c_tail <= i * vlen_numbers)
+                    continue;
                 for (int kw = 0; kw < jcp.kw; kw++) {
-                    int ker_off = ch*jcp.kd*jcp.kh*jcp.kw*ch_blk + kw*ch_blk + i*4;
+                    int ker_off = ch*jcp.kd*jcp.kh*jcp.kw*ch_blk + kw*ch_blk + i*vlen_numbers;
 
                     Vmm vmm_ker = get_ker_reg(0);
                     uni_vmovups(vmm_ker, ptr[aux_reg_kernel
                         + ker_off*sizeof(float)]);
 
                     for (int ow = 0; ow < ur_w; ow++) {
-                        int inp_off = ch*jcp.id*jcp.ih*jcp.iw*ch_blk
-                            + ow*stride_w*ch_blk + kw*ch_blk*dilate_w + i*4;
+                        int inp_off = ch*icb_stride
+                            + ow*stride_w*iw_stride + kw*dilate_w*iw_stride + i*vlen_numbers;
 
                         Vmm vmm_src = get_src_reg(0);
-                        uni_vmovups(vmm_src, ptr[aux_reg_input
-                            + inp_off*sizeof(float)]);
+                        if (is_tail_load) {
+                            load_tail(vmm_src, aux_reg_input,
+                                      inp_off * sizeof(float),
+                                      (c_tail - i*vlen_numbers) * sizeof(float));
+                        } else {
+                            uni_vmovups(vmm_src,
+                                        ptr[aux_reg_input + inp_off*sizeof(float)]);
+                        }
 
                         Vmm vmm_acc = get_acc_reg(i*ur_ch_blocks*ur_w
                             + ch*ur_w + ow);
@@ -217,7 +305,7 @@ void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::apply_filter_unrolled(
         }
 
         add(aux_reg_kernel, jcp.kw*ch_blk*sizeof(float));
-        add(aux_reg_input, jcp.iw*ch_blk*dilate_h*sizeof(float));
+        add(aux_reg_input, ih_stride*dilate_h*sizeof(float));
 
         dec(iter_kh);
         cmp(iter_kh, 0);
@@ -228,7 +316,7 @@ void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::apply_filter_unrolled(
 
     if (jcp.ndims == 5) {
         add(aux_reg_ker_d, jcp.kh*jcp.kw*ch_blk*sizeof(float));
-        add(aux_reg_inp_d, jcp.ih*dilate_d*jcp.iw*ch_blk*sizeof(float));
+        add(aux_reg_inp_d, jcp.ih*dilate_d*ih_stride*sizeof(float));
 
         mov(aux_reg_input, aux_reg_inp_d);
         mov(aux_reg_kernel, aux_reg_ker_d);
@@ -241,6 +329,7 @@ void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::apply_filter_unrolled(
         pop(reg_input);
 
         L(iter_d_exit_label);
+        pop(reg_kd);
     }
 }
 
@@ -262,11 +351,14 @@ void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::apply_postprocess(int ur_ch_block
             eltwise_injectors[eltwise_inj_idx]->compute_vector_range(start_idx, end_idx);
             eltwise_inj_idx++;
         } else if (post_op.is_depthwise()) {
+            push(aux_reg_blocks_offset);
+            add(aux_reg_blocks_offset, ptr[this->param1 + GET_OFF(oc_off)]); //add offset of processed blocks
+
             mov(reg_d_weights, reinterpret_cast<size_t>(post_op.depthwise.weights_data));
             mov(reg_d_bias, reinterpret_cast<size_t>(post_op.depthwise.biases_data));
 
-            add(reg_d_weights, ptr[this->param1 + GET_OFF(oc_off)]);
-            add(reg_d_bias, ptr[this->param1 + GET_OFF(oc_off)]);
+            add(reg_d_weights, aux_reg_blocks_offset);
+            add(reg_d_bias, aux_reg_blocks_offset);
 
             for (int ch = 0; ch < ur_ch_blocks; ch++) {
                 for (int k = 0; k < repeats; k++) {
@@ -280,10 +372,14 @@ void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::apply_postprocess(int ur_ch_block
                     add(reg_d_bias, jcp.ch_block / repeats * sizeof(float));
                 }
             }
+            pop(aux_reg_blocks_offset);
 
             depthwise_inj_idx++;
         } else if (post_op.is_quantization()) {
-            quantization_injectors[quantization_inj_idx]->init_crop_ptrs(ptr[this->param1 + GET_OFF(oc_off)]);
+            push(aux_reg_blocks_offset);
+            add(aux_reg_blocks_offset, ptr[this->param1 + GET_OFF(oc_off)]); //add offset of processed blocks
+
+            quantization_injectors[quantization_inj_idx]->init_crop_ptrs(aux_reg_blocks_offset);
             for (int ch = 0; ch < ur_ch_blocks; ch++) {
                 for (int k = 0; k < repeats; k++) {
                     int s_idx = get_acc_reg(k*ur_ch_blocks*ur_w + ch*ur_w).getIdx();
@@ -292,7 +388,7 @@ void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::apply_postprocess(int ur_ch_block
                 }
             }
 
-            quantization_injectors[quantization_inj_idx]->init_input_scale_shift_ptrs(ptr[this->param1 + GET_OFF(oc_off)]);
+            quantization_injectors[quantization_inj_idx]->init_input_scale_shift_ptrs(aux_reg_blocks_offset);
             for (int ch = 0; ch < ur_ch_blocks; ch++) {
                 for (int k = 0; k < repeats; k++) {
                     int s_idx = get_acc_reg(k*ur_ch_blocks*ur_w + ch*ur_w).getIdx();
@@ -301,7 +397,7 @@ void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::apply_postprocess(int ur_ch_block
                 }
             }
 
-            quantization_injectors[quantization_inj_idx]->init_output_scale_shift_ptrs(ptr[this->param1 + GET_OFF(oc_off)]);
+            quantization_injectors[quantization_inj_idx]->init_output_scale_shift_ptrs(aux_reg_blocks_offset);
             for (int ch = 0; ch < ur_ch_blocks; ch++) {
                 for (int k = 0; k < repeats; k++) {
                     int s_idx = get_acc_reg(k*ur_ch_blocks*ur_w + ch*ur_w).getIdx();
@@ -309,6 +405,7 @@ void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::apply_postprocess(int ur_ch_block
                                                                                              (k * (jcp.ch_block / 2) + ch * jcp.ch_block) * sizeof(float));
                 }
             }
+            pop(aux_reg_blocks_offset);
 
             quantization_inj_idx++;
         }
@@ -316,20 +413,174 @@ void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::apply_postprocess(int ur_ch_block
 }
 
 template <cpu_isa_t isa>
-void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::store_dst(
-        int ur_ch_blocks, int ur_w) {
-    int ch_blk = jcp.ch_block;
+void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::load_tail(
+        Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset, int load_size) {
+    uni_vmovups(vmm | k_oc_tail_mask | T_z, ptr[reg + offset]);
+}
 
-    int repeats = isa == sse41 ? 2 : 1;
+template <>
+void jit_uni_fork_dw_conv_fwd_kernel_f32<avx2>::load_tail(
+        Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset, int load_size) {
+    load_bytes(vmm, reg, offset, load_size);
+}
+
+template <>
+void jit_uni_fork_dw_conv_fwd_kernel_f32<sse41>::load_tail(
+        Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset, int load_size) {
+    load_bytes(vmm, reg, offset, load_size);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::add_tail_from_mem(Vmm &vmm_acc,
+                                                                 Vmm &vmm_tmp, const Xbyak::Reg64 &reg, int64_t offset, int load_size) {
+    uni_vaddps(vmm_acc | k_oc_tail_mask | T_z, vmm_acc, ptr[reg + offset]);
+}
+
+template <>
+void jit_uni_fork_dw_conv_fwd_kernel_f32<avx2>::add_tail_from_mem(Vmm &vmm_acc,
+                                                                  Vmm &vmm_tmp, const Xbyak::Reg64 &reg, int64_t offset, int load_size) {
+    load_bytes(vmm_tmp, reg, offset, load_size);
+    uni_vaddps(vmm_acc, vmm_acc, vmm_tmp);
+}
+
+template <>
+void jit_uni_fork_dw_conv_fwd_kernel_f32<sse41>::add_tail_from_mem(Vmm &vmm_acc,
+                                                                   Vmm &vmm_tmp, const Xbyak::Reg64 &reg, int64_t offset, int load_size) {
+    load_bytes(vmm_tmp, reg, offset, load_size);
+    uni_vaddps(vmm_acc, vmm_acc, vmm_tmp);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::store_tail(
+        Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset, int store_size) {
+    uni_vmovups(vmmword[reg + offset], vmm | k_oc_tail_mask);
+}
+
+template <>
+void jit_uni_fork_dw_conv_fwd_kernel_f32<avx2>::store_tail(
+        Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset, int store_size) {
+    store_bytes(vmm, reg, offset, store_size);
+}
+
+template <>
+void jit_uni_fork_dw_conv_fwd_kernel_f32<sse41>::store_tail(
+        Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset, int store_size) {
+    store_bytes(vmm, reg, offset, store_size);
+}
+
+
+template <cpu_isa_t isa>
+void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::store_dst(
+        int ur_ch_blocks, int ur_w, bool is_ch_tail) {
+    const auto dst_layout_nxc = is_dst_layout_nxc();
+    const auto ch_blk = jcp.ch_block;
+    const auto ocb_stride = dst_layout_nxc ? ch_blk : jcp.od * jcp.oh * jcp.ow * ch_blk;
+    const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
+    const int vlen_numbers = cpu_isa_traits<isa>::vlen / sizeof(float);
+    const int c_tail = jcp.oc_without_padding % jcp.ch_block;
+
+    int repeats = jcp.ch_block / vlen_numbers;
+    assert((repeats == 1) || (repeats == 2 && isa == sse41));
     for (int i = 0; i < repeats; i++) {
         for (int ch = 0; ch < ur_ch_blocks; ch++) {
+            const bool is_tail_load = check_if_tail_load(
+                    is_ch_tail, c_tail, ch, ur_ch_blocks, vlen_numbers, i);
+            if ((ch + 1 == ur_ch_blocks) && is_ch_tail && c_tail <= i * vlen_numbers)
+                continue;
             for (int ow = 0; ow < ur_w; ow++) {
-                int o_off = ch*jcp.od*jcp.oh*jcp.ow*ch_blk + ow*ch_blk + i*4;
+                int o_off = ch*ocb_stride + ow*ow_stride + i*vlen_numbers;
                 Vmm vmm_dst = get_acc_reg(i*ur_ch_blocks*ur_w + ch*ur_w + ow);
 
-                uni_vmovups(vmmword[reg_output + o_off*sizeof(float)], vmm_dst);
+                if (is_tail_load) {
+                    store_tail(vmm_dst, reg_output, o_off * sizeof(float),
+                               (c_tail - i*vlen_numbers) * sizeof(float));
+                } else
+                    uni_vmovups(vmmword[reg_output + o_off*sizeof(float)], vmm_dst);
             }
         }
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::compute_loop(int ur_w, int ur_ch_blocks) {
+    const bool ch_loop = ur_ch_blocks > jcp.nb_ch_blocking;
+    // ch_loop currently happen only when data layout is nxc. The strides are
+    // calculated for this layout only.
+    const size_t wei_ch_stride = (size_t)jcp.nb_ch_blocking * jcp.kd * jcp.kh * jcp.kw
+                                 * jcp.ch_block * sizeof(float);
+    const size_t inp_ch_stride
+            = (size_t)jcp.nb_ch_blocking * jcp.ch_block * sizeof(float);
+    const size_t out_ch_stride
+            = (size_t)jcp.nb_ch_blocking * jcp.ch_block * sizeof(float);
+    const size_t bias_stride
+            = (size_t)jcp.nb_ch_blocking * jcp.ch_block * sizeof(float);
+
+    auto compute = [&](int ur_ch_blocks, bool is_ch_tail) {
+        mov(aux_reg_input, reg_input);
+        mov(aux_reg_kernel, reg_kernel);
+
+        load_src(ur_ch_blocks, ur_w, is_ch_tail);
+        if (ur_w == 1) {
+            apply_filter(ur_ch_blocks, ur_w, is_ch_tail);
+        } else {
+            apply_filter_unrolled(ur_ch_blocks, ur_w, is_ch_tail);
+        }
+        apply_postprocess(ur_ch_blocks, ur_w);
+        store_dst(ur_ch_blocks, ur_w, is_ch_tail);
+    };
+
+    xor_(aux_reg_blocks_offset, aux_reg_blocks_offset);
+
+    if (ch_loop) {
+        Label ch_loop_label, ch_tail_label, skip_ch_tail_label;
+        const int ch_block_tail = jcp.nb_ch
+                                  - (utils::rnd_dn(jcp.oc / jcp.ch_block, jcp.nb_ch_blocking));
+        const int ch_step = jcp.nb_ch_blocking * jcp.ch_block;
+
+        push(aux_reg_ch_blocks);
+        mov(aux_reg_ch_blocks, reg_ch_blocks);
+        push(reg_kernel);
+        push(reg_input);
+        push(reg_output);
+        if (jcp.with_bias) push(reg_bias);
+
+        if ((jcp.oc / jcp.ch_block) >= jcp.nb_ch_blocking) {
+            if (ch_block_tail) {
+                cmp(aux_reg_ch_blocks, ch_step);
+                jl(ch_tail_label, T_NEAR);
+            }
+
+            L(ch_loop_label);
+            {
+                compute(jcp.nb_ch_blocking, false);
+                add(reg_kernel, wei_ch_stride);
+                add(reg_input, inp_ch_stride);
+                add(reg_output, out_ch_stride);
+                if (jcp.with_bias) add(reg_bias, bias_stride);
+                sub(aux_reg_ch_blocks, ch_step);
+                add(aux_reg_blocks_offset, ch_step * sizeof(float)); //add initial offset of processed blocks
+                cmp(aux_reg_ch_blocks, ch_step);
+                jge(ch_loop_label, T_NEAR);
+            }
+        }
+
+        if (ch_block_tail) {
+            // ch work range [1, jcp.nb_ch_blocking * ch_block)
+            L(ch_tail_label);
+            cmp(aux_reg_ch_blocks, 0);
+            jle(skip_ch_tail_label, T_NEAR);
+            compute(ch_block_tail, jcp.oc % jcp.ch_block);
+            L(skip_ch_tail_label);
+        }
+
+        if (jcp.with_bias) pop(reg_bias);
+        pop(reg_output);
+        pop(reg_input);
+        pop(reg_kernel);
+        pop(aux_reg_ch_blocks);
+
+    } else {
+        compute(ur_ch_blocks, jcp.oc % jcp.ch_block);
     }
 }
 
@@ -339,22 +590,22 @@ void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::loop_body(int ur_ch_blocks) {
     Label tail_w_label;
     Label exit_label;
 
+    const auto src_layout_nxc = is_src_layout_nxc();
+    const auto dat_c_stride = src_layout_nxc ? jcp.ngroups : jcp.ch_block;
+
     L(unrolled_w_label); {
         int ur_w = jcp.ur_w;
+
+        size_t inp_shift = sizeof(float) * ur_w * jcp.stride_w * dat_c_stride;
+        size_t out_shift = sizeof(float) * ur_w * dat_c_stride;
 
         cmp(reg_ur_w, ur_w);
         jl(tail_w_label, T_NEAR);
 
-        mov(aux_reg_input, reg_input);
-        mov(aux_reg_kernel, reg_kernel);
+        compute_loop(ur_w, ur_ch_blocks);
 
-        load_src(ur_ch_blocks, ur_w);
-        apply_filter_unrolled(ur_ch_blocks, ur_w);
-        apply_postprocess(ur_ch_blocks, ur_w);
-        store_dst(ur_ch_blocks, ur_w);
-
-        add(reg_input, sizeof(float) * ur_w * jcp.ch_block * jcp.stride_w);
-        add(reg_output, sizeof(float) * ur_w * jcp.ch_block);
+        add(reg_input, inp_shift);
+        add(reg_output, out_shift);
 
         sub(reg_ur_w, ur_w);
         jmp(unrolled_w_label);
@@ -363,19 +614,16 @@ void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::loop_body(int ur_ch_blocks) {
     L(tail_w_label); {
         int ur_w = 1;
 
+        size_t inp_shift = sizeof(float) * ur_w * jcp.stride_w * dat_c_stride;
+        size_t out_shift = sizeof(float) * ur_w * dat_c_stride;
+
         cmp(reg_ur_w, ur_w);
         jl(exit_label, T_NEAR);
 
-        mov(aux_reg_input, reg_input);
-        mov(aux_reg_kernel, reg_kernel);
+        compute_loop(ur_w, ur_ch_blocks);
 
-        load_src(ur_ch_blocks, ur_w);
-        apply_filter(ur_ch_blocks, ur_w);
-        apply_postprocess(ur_ch_blocks, ur_w);
-        store_dst(ur_ch_blocks, ur_w);
-
-        add(reg_input, sizeof(float) * ur_w * jcp.ch_block * jcp.stride_w);
-        add(reg_output, sizeof(float) * ur_w * jcp.ch_block);
+        add(reg_input, inp_shift);
+        add(reg_output, out_shift);
 
         sub(reg_ur_w, ur_w);
         jmp(tail_w_label);
@@ -416,29 +664,42 @@ void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::generate() {
     if (jcp.with_bias)
         mov(reg_bias, ptr[this->param1 + GET_OFF(bias)]);
     mov(reg_kw, ptr[this->param1 + GET_OFF(kw_padding)]);
-    mov(reg_ch_blocks, ptr[this->param1 + GET_OFF(ch_blocks)]);
+    mov(reg_ch_blocks, ptr[this->param1 + GET_OFF(load_work)]);
     mov(reg_ur_w, ptr[this->param1 + GET_OFF(ur_w)]);
 
     Label ch_blocks_tail_label;
     Label exit_label;
 
     int ch_blocks_tail = jcp.nb_ch % jcp.nb_ch_blocking;
-
-    cmp(reg_ch_blocks, jcp.nb_ch_blocking);
-    jne(ch_blocks_tail ? ch_blocks_tail_label : exit_label, T_NEAR);
-
-    loop_body(jcp.nb_ch_blocking); // channel main loop
-
-    if (ch_blocks_tail) {
-        L(ch_blocks_tail_label);
-
-        cmp(reg_ch_blocks, ch_blocks_tail);
-        jne(exit_label, T_NEAR);
-
-        loop_body(ch_blocks_tail); // channel tail loop
+    if (isa & avx512_common_bit) {
+        const auto oc_tail = jcp.oc_without_padding % jcp.ch_block;
+        if (oc_tail != 0) {
+            // Prepare masks for tailing
+            const int oc_tail_shift
+                    = jcp.ch_block - jcp.oc_without_padding % jcp.ch_block;
+            static constexpr auto zmm_full_mask = ((1 << 16) - 1);
+            Reg32 reg_tail_32 = reg_tail.cvt32();
+            mov(reg_tail_32, (zmm_full_mask >> oc_tail_shift));
+            kmovw(k_oc_tail_mask, reg_tail_32);
+        }
     }
 
-    L(exit_label);
+    if (is_src_layout_nxc()) {
+        loop_body(jcp.nb_ch);
+    } else {
+        cmp(reg_ch_blocks, (jcp.nb_ch_blocking - 1) * jcp.ch_block);
+        jle(ch_blocks_tail ? ch_blocks_tail_label : exit_label, T_NEAR);
+
+        loop_body(jcp.nb_ch_blocking); // channel main loop
+
+        if (ch_blocks_tail) {
+            jmp(exit_label, T_NEAR);
+            L(ch_blocks_tail_label);
+            loop_body(ch_blocks_tail); // channel tail loop
+        }
+
+        L(exit_label);
+    }
 
     this->postamble();
 

--- a/src/cpu/x64/jit_uni_fork_dw_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_uni_fork_dw_conv_kernel_f32.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020 Intel Corporation
+* Copyright 2021 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -59,6 +59,7 @@ struct jit_uni_fork_dw_conv_fwd_kernel_f32 : public jit_generator {
 private:
     using Vmm = typename utils::conditional3<isa == sse41, Xbyak::Xmm,
         isa == avx2, Xbyak::Ymm, Xbyak::Zmm>::type;
+    using mask_t = const Xbyak::Opmask;
     using reg64_t = const Xbyak::Reg64;
     const Xbyak::AddressFrame &vmmword = (isa == sse41)
         ? xword : (isa == avx2) ? yword : zword;
@@ -70,23 +71,28 @@ private:
     reg64_t aux1_reg_input = r10;
     reg64_t reg_kernel = r11;
     reg64_t aux_reg_kernel = r12;
-    reg64_t aux1_reg_kernel = r13;
+    reg64_t reg_ch_blocks = r13;
     reg64_t reg_output = r14;
     reg64_t reg_bias = r15;
-    reg64_t reg_kh = rax;
+    reg64_t reg_tail = rax;
     reg64_t reg_kw = rbx;
     reg64_t iter_kh = rdx;
     reg64_t iter_kw = rsi;
     reg64_t reg_ur_w = rbp;
-    reg64_t reg_ch_blocks = aux1_reg_input;
+    reg64_t reg_kh = reg_tail;
+    reg64_t aux1_reg_kernel = reg_ch_blocks;
     reg64_t imm_addr64 = aux1_reg_input;
+    reg64_t aux_reg_ch_blocks = reg_ur_w;
+    reg64_t aux_reg_blocks_offset = abi_not_param1;
 
     reg64_t reg_d_weights = imm_addr64;
     reg64_t reg_d_bias = iter_kh;
 
-    reg64_t reg_kd = abi_not_param1;
+    reg64_t reg_kd = aux_reg_blocks_offset;
     reg64_t aux_reg_inp_d = reg_input;
     reg64_t aux_reg_ker_d = reg_kernel;
+
+    mask_t k_oc_tail_mask = Xbyak::Opmask(2);
 
     Vmm vmm_d_weights = Vmm(0);
     Vmm vmm_d_bias = Vmm(1);
@@ -95,12 +101,29 @@ private:
     inline Vmm get_src_reg(int idx) { return Vmm(idx + 1); }
     inline Vmm get_acc_reg(int idx) { return Vmm(idx + 4); }
 
-    inline void load_src(int ur_ch_blocks, int ur_w);
-    inline void apply_filter(int ur_ch_blocks, int ur_w);
-    inline void apply_filter_unrolled(int ur_ch_blocks, int ur_w);
+    inline bool is_src_layout_nxc() {
+        return utils::one_of(jcp.src_tag, format_tag::ndhwc, format_tag::nhwc,
+                             format_tag::nwc);
+    }
+    inline bool is_dst_layout_nxc() {
+        return utils::one_of(jcp.dst_tag, format_tag::ndhwc, format_tag::nhwc,
+                             format_tag::nwc);
+    }
+
+    inline void load_src(int ur_ch_blocks, int ur_w, bool is_ch_tail);
+    inline void compute_loop(int ur_w, int ur_ch_blocks);
+    inline void apply_filter(int ur_ch_blocks, int ur_w, bool is_ch_tail);
+    inline void apply_filter_unrolled(int ur_ch_blocks, int ur_w, bool is_ch_tail);
     inline void apply_postprocess(int ur_ch_blocks, int ur_w);
-    inline void store_dst(int ur_ch_blocks, int ur_w);
+    inline void store_dst(int ur_ch_blocks, int ur_w, bool is_ch_tail);
     inline void loop_body(int ur_ch_blocks);
+
+    void load_tail(
+            Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset, int load_size);
+    void add_tail_from_mem(Vmm &vmm_acc, Vmm &vmm_tmp, const Xbyak::Reg64 &reg,
+                           int64_t offset, int load_size);
+    void store_tail(
+            Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset, int store_size);
 
     void generate() override;
 

--- a/src/cpu/x64/jit_uni_fork_dw_conv_kernel_utils.hpp
+++ b/src/cpu/x64/jit_uni_fork_dw_conv_kernel_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2019-2020 Intel Corporation
+* Copyright 2019-2021 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -111,14 +111,14 @@ status_t jit_uni_fork_dw_conv_fwd_kernel<isa, kernel_dt>::init_conf(
                                           : one_of(isa, avx512_common, avx512_core) ? nChw16c : nChw8c;
     const auto wei_tag = (ndims == 5) ? one_of(isa, avx512_common, avx512_core) ? Goidhw16g : Goidhw8g
                                       : one_of(isa, avx512_common, avx512_core) ? Goihw16g : Goihw8g;
-
+    const auto nxc_tag = (ndims == 5) ? ndhwc : nhwc;
     jcp.with_bias = cd.bias_desc.format_kind != format_kind::undef;
 
     if (src_d.format_kind() == format_kind::any) {
         CHECK(memory_desc_init_by_tag(src_md, blocked_tag));
         jcp.src_tag = blocked_tag;
     } else {
-        jcp.src_tag = src_d.mb_stride_relaxed_match(blocked_tag);
+        jcp.src_tag = src_d.mb_stride_relaxed_match(blocked_tag, nxc_tag);
     }
 
     if (weights_d.format_kind() == format_kind::any) {
@@ -132,7 +132,7 @@ status_t jit_uni_fork_dw_conv_fwd_kernel<isa, kernel_dt>::init_conf(
         CHECK(memory_desc_init_by_tag(dst_md, blocked_tag));
         jcp.dst_tag = blocked_tag;
     } else {
-        jcp.dst_tag = dst_d.mb_stride_relaxed_match(blocked_tag);
+        jcp.dst_tag = dst_d.mb_stride_relaxed_match(blocked_tag, nxc_tag);
     }
 
     if (jcp.with_bias) {
@@ -142,8 +142,11 @@ status_t jit_uni_fork_dw_conv_fwd_kernel<isa, kernel_dt>::init_conf(
 
     if (jcp.dst_tag != jcp.src_tag) return status::unimplemented;
     const auto data_tag = jcp.src_tag;
+    const bool is_data_layout_nxc = data_tag == nxc_tag;
 
     const bool is_bf16 = src_d.data_type() == data_type::bf16;
+    // 3D bf16 fork DW kernel does not support 3D convolution
+    if (is_bf16 && ndims == 5) return status::unimplemented;
 
     jcp.dst_dt = cd.dst_desc.data_type;
     jcp.isa = (is_bf16 && mayiuse(avx512_core_bf16)) ? avx512_core_bf16 : isa;
@@ -193,6 +196,12 @@ status_t jit_uni_fork_dw_conv_fwd_kernel<isa, kernel_dt>::init_conf(
     jcp.dilate_h = cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
+    jcp.loop_order = loop_ngcw;
+
+    if (is_data_layout_nxc) {
+        jcp.loop_order = loop_nhwcg;
+    }
+
     if (!post_ops_ok(jcp, attr))
             return status::unimplemented;
 
@@ -204,6 +213,7 @@ status_t jit_uni_fork_dw_conv_fwd_kernel<isa, kernel_dt>::init_conf(
         jcp.eltwise = p.entry_[eltwise_ind].eltwise;
 
     bool ok_to_pad_channels = true
+        && !is_data_layout_nxc
         && jcp.oc == jcp.ngroups
         && jcp.ic == jcp.ngroups
         && one_of(isa, avx512_common, avx512_core, avx2);
@@ -214,7 +224,8 @@ status_t jit_uni_fork_dw_conv_fwd_kernel<isa, kernel_dt>::init_conf(
     }
 
     bool args_ok = true && jcp.oc == jcp.ngroups && jcp.ic == jcp.ngroups
-                   && jcp.ngroups % simd_w == 0 && jcp.wei_tag == wei_tag
+                   && IMPLICATION(!is_data_layout_nxc, jcp.ngroups % simd_w == 0)
+                   && jcp.wei_tag == wei_tag
                    && data_tag != format_tag::undef && jcp.ic <= src_d.padded_dims()[1]
                    && jcp.oc <= dst_d.padded_dims()[1]
                    && jcp.ngroups <= weights_d.padded_dims()[0];
@@ -230,7 +241,7 @@ status_t jit_uni_fork_dw_conv_fwd_kernel<isa, kernel_dt>::init_conf(
                        : isa == avx512_common ? 6 : isa == avx2 ? 4 : 3;
 
     jcp.ch_block = simd_w;
-    jcp.nb_ch = jcp.oc / jcp.ch_block;
+    jcp.nb_ch = div_up(jcp.oc, jcp.ch_block);
     jcp.nb_ch_blocking
             = one_of(isa, avx512_common, avx512_core) ? 4 : isa == avx2 ? 3 : 2;
     if (jcp.nb_ch < jcp.nb_ch_blocking)

--- a/src/cpu/x64/jit_uni_fork_dw_convolution.hpp
+++ b/src/cpu/x64/jit_uni_fork_dw_convolution.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020 Intel Corporation
+* Copyright 2021 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/src/cpu/x64/jit_uni_planar_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_uni_planar_conv_kernel_f32.cpp
@@ -744,7 +744,7 @@ status_t jit_uni_planar_conv_fwd_kernel_f32<isa>::init_conf(jit_conv_conf_t &jcp
     if (!set_or_check_wei_format())
         return status::unimplemented;
 
-    auto dat_tag = ndims == 5 ? format_tag::ncdhw : format_tag::nhwc;
+    auto dat_tag = ndims == 5 ? format_tag::ncdhw : format_tag::nchw;
     if (src_d.format_kind() == format_kind::any) {
         CHECK(memory_desc_init_by_tag(src_md, dat_tag));
         jcp.src_tag = dat_tag;


### PR DESCRIPTION
# Description

Enabling nspc layout support in all the FP32/BF16 convolution primitives

## Checklist

- [x] Add all necessary guard checks if the convolution primitive does not support nspc layout
- [x] Fix fusing post ops for the nspc layot in the gemm convolution 
- [x] Fix fusing post ops for the nspc layout in DW convolution
- [x] Backport nspc layout support and nspc ic and oc tails support into the fork DW convolution from v2.2

## Known issues

- SSE41 convolution kernels do not support nspc layout
- GEMM BF16 ncsp convolution unexpectedly crushes during multithreaded execution 
- GEMM FP32/BF16 nspc depthwise post ops fusing implementation is not optimal 

OpenVINO PR: https://github.com/openvinotoolkit/openvino/pull/5292