### PR TITLE
Enable Matmul primitives in order to use them in plugin

### DIFF
--- a/src/cpu/matmul/cpu_matmul_list.cpp
+++ b/src/cpu/matmul/cpu_matmul_list.cpp
@@ -37,7 +37,6 @@ using namespace dnnl::impl::cpu::matmul;
 
 // clang-format off
 const impl_list_item_t impl_list[] = {
-#ifdef ENABLE_UNUSED_PRIM
         CPU_INSTANCE(gemm_f32_matmul_t)
         CPU_INSTANCE_X64(brgemm_matmul_t, avx512_core_bf16_amx_bf16)
         CPU_INSTANCE(gemm_bf16_matmul_t, f32)
@@ -62,7 +61,6 @@ const impl_list_item_t impl_list[] = {
         CPU_INSTANCE(ref_matmul_t, u8, s8, s32, s32)
         CPU_INSTANCE(ref_matmul_t, u8, s8, s8, s32)
         CPU_INSTANCE(ref_matmul_t, u8, s8, u8, s32)
-#endif
         /* eol */
         nullptr,
 };


### PR DESCRIPTION
In scope of replacing SGEMM with MatMul

Ticket:
- 48230

Openvino update:
- https://github.com/openvinotoolkit/openvino/pull/6785