### PR TITLE
Enable direct copy primitives for u8 reorder

### DIFF
--- a/src/cpu/cpu_reorder.cpp
+++ b/src/cpu/cpu_reorder.cpp
@@ -138,6 +138,13 @@ using impl_list_map_t = std::map<reorder_impl_key_t, std::vector<rpd_create_f>>;
 #define REG_FAST_DIRECT_COPY_COMMA(sdt, ddt)
 #endif
 
+#ifdef __INTEL_COMPILER
+/* Enable direct copy primitives for non-icc compilers, but place it after the jitted ones */
+#define REG_FAST_DIRECT_COPY_AFTER_JIT(sdt, ddt)
+#else
+#define REG_FAST_DIRECT_COPY_AFTER_JIT(sdt, ddt) REG_SR_DIRECT_COPY(sdt, ddt)
+#endif
+
 // clang-format off
 
 const impl_list_map_t regular_impl_list_map {
@@ -506,6 +513,13 @@ const impl_list_map_t regular_impl_list_map {
         REG_FAST_DIRECT_COPY_COMMA(u8, u8)
 
         DNNL_X64_ONLY(REG_REORDER_FN(uni_reorder_t))
+
+        // Allow direct-copy primitives for non-intel compilers, but with a lower priority than the jitted impl
+        REG_FAST_DIRECT_COPY_AFTER_JIT(u8, f32)
+        REG_FAST_DIRECT_COPY_AFTER_JIT(u8, s32)
+        REG_FAST_DIRECT_COPY_AFTER_JIT(u8, bf16)
+        REG_FAST_DIRECT_COPY_AFTER_JIT(u8, s8)
+        REG_FAST_DIRECT_COPY_AFTER_JIT(u8, u8)
 
         REG_SR_BIDIR(u8, any, f32, nChw16c)
         REG_SR_BIDIR(u8, any, s32, nChw16c)


### PR DESCRIPTION
### Details:
 - *Enable u8 reorder direct-copy primitives to fix yolo_v2_tiny_voc performance*

### Tickets:
 - *57223*

### OV PR: 
 - *https://github.com/openvinotoolkit/openvino/pull/7043*