### PR TITLE
Fix c26453 warning (left shift of a negative signed number)

### DIFF
--- a/src/cpu/x64/jit_uni_reorder.cpp
+++ b/src/cpu/x64/jit_uni_reorder.cpp
@@ -1097,7 +1097,7 @@ struct jit_single_blk_kernel_t : public jit_generator {
         vxorps(ymm_tmp, ymm_tmp, ymm_tmp);
         vpcmpeqd(ymm_mask, ymm_mask, ymm_mask);
         // blend in
-        auto in_mask = -1 << mask;
+        auto in_mask = static_cast<unsigned>(-1) << mask;
         vpblendd(ymm_mask, ymm_mask, ymm_tmp, in_mask);
     }
 


### PR DESCRIPTION
# Description

Fix "Arithmetic overflow: Left shift of a negative signed number is undefined behavior" warning C26453

Fixes # CVS-61472
