### PR TITLE
Resolve "pointer index expression overflowed" in `_ref_rnn_common_t()`

### DIFF
--- a/src/cpu/rnn/ref_rnn.cpp
+++ b/src/cpu/rnn/ref_rnn.cpp
@@ -1139,7 +1139,7 @@ void _ref_rnn_common_t<aprop, src_type, weights_type, acc_type>::execute_(
     auto diff_bias = CTX_OUT_MEM(float *, DNNL_ARG_DIFF_BIAS);
 
     // Fetching extra buffers from scratchpad
-    float *ws_bias = (float *)(scratch_ptr + ws_bias_offset_);
+    float *ws_bias = (float *)((uintptr_t)scratch_ptr + ws_bias_offset_);
 
     // initialize diff_states to 0
     if (aprop == prop_kind::backward) {


### PR DESCRIPTION
# Description

Fix `pointer index expression with base 0x... overflowed to 0x...` in `_ref_rnn_common_t()` by using `uintptr_t` for pointer arithmetic. But current solution is less portable due `uintptr_t` is optional type from compiler perspective

Fixes # 
CVS-61473
