### PR TITLE
Dyn batch hadling to some convolutions and mem desc comparison restri…

### DIFF
--- a/src/common/type_helpers.hpp
+++ b/src/common/type_helpers.hpp
@@ -205,10 +205,7 @@ inline bool blocking_desc_is_equal(const memory_desc_t &lhs_md,
             && array_cmp(lhs.inner_idxs, rhs.inner_idxs, lhs.inner_nblks);
     if (ignore_strides) return equal;
 
-    // Check the strides.
-    // Note: for dimensions of size `1` the stride doesn't really matter.
     for (int d = 0; d < lhs_md.ndims; ++d) {
-        if (lhs_md.dims[d] == 1 && lhs_md.padded_dims[d] == 1) continue;
         equal = equal && lhs.strides[d] == rhs.strides[d];
     }
 

--- a/src/cpu/x64/jit_uni_planar_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_uni_planar_conv_kernel_f32.cpp
@@ -749,7 +749,7 @@ status_t jit_uni_planar_conv_fwd_kernel_f32<isa>::init_conf(jit_conv_conf_t &jcp
         CHECK(memory_desc_init_by_tag(src_md, dat_tag));
         jcp.src_tag = dat_tag;
     } else {
-        jcp.src_tag = src_d.matches_one_of_tag(dat_tag);
+        jcp.src_tag = src_d.mb_stride_relaxed_match(dat_tag);
     }
     if (jcp.src_tag != dat_tag)
         return status::unimplemented;
@@ -758,7 +758,7 @@ status_t jit_uni_planar_conv_fwd_kernel_f32<isa>::init_conf(jit_conv_conf_t &jcp
         CHECK(memory_desc_init_by_tag(dst_md, dat_tag));
         jcp.dst_tag = dat_tag;
     } else {
-        jcp.dst_tag = dst_d.matches_one_of_tag(dat_tag);
+        jcp.dst_tag = dst_d.mb_stride_relaxed_match(dat_tag);
     }
     if (jcp.dst_tag != dat_tag)
         return status::unimplemented;


### PR DESCRIPTION
# Description

Fixes to support OV dynamic shapes implementation on oneDNN side. Two main changes were done:
1. Added support for dynamic minibatch in some convolution implementations
2. Restricted memory desc comparison operator so it now consider all strides even though the dimension has value equal 1.

OV repo PR https://github.com/openvinotoolkit/openvino/pull/8047
