### PR TITLE
fix comma bug in def register

### DIFF
--- a/src/common/impl_registration.hpp
+++ b/src/common/impl_registration.hpp
@@ -49,14 +49,14 @@
 #define REG_BINARY_P(...) __VA_ARGS__
 #else
 #define REG_BINARY_P(...) \
-    { nullptr },
+    { nullptr }
 #endif
 
 #if BUILD_PRIMITIVE_ALL || BUILD_CONCAT
 #define REG_CONCAT_P(...) __VA_ARGS__
 #else
 #define REG_CONCAT_P(...) \
-    { nullptr },
+    { nullptr }
 #endif
 
 #if BUILD_PRIMITIVE_ALL || BUILD_CONVOLUTION
@@ -121,7 +121,7 @@
 #define REG_MATMUL_P(...) __VA_ARGS__
 #else
 #define REG_MATMUL_P(...) \
-    { nullptr }, 
+    { nullptr }
 #endif
 
 #if BUILD_PRIMITIVE_ALL || BUILD_POOLING
@@ -142,7 +142,7 @@
 #define REG_REDUCTION_P(...) __VA_ARGS__
 #else
 #define REG_REDUCTION_P(...) \
-    { nullptr }, 
+    { nullptr }
 #endif
 
 #if BUILD_PRIMITIVE_ALL || BUILD_REORDER
@@ -184,7 +184,7 @@
 #define REG_SUM_P(...) __VA_ARGS__
 #else
 #define REG_SUM_P(...) \
-    { nullptr },
+    { nullptr }
 #endif
 
 // Primitive CPU ISA section is in src/cpu/platform.hpp


### PR DESCRIPTION
# Description

Fix bug in register definition by deleting commas.



# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
