### PR TITLE
SSE41 support in uni_vsubss and uni_vmulss

### DIFF
--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -721,7 +721,8 @@ public:
             // previously there was "subps(x, op2)" for some reason
             vsubss(x, op1, op2);
         else {
-            assert(x.isEqualIfNotInherited(op1));
+            if (!x.isEqualIfNotInherited(op1))
+                movss(x, op1);
             subss(x, op2);
         }
     }
@@ -794,7 +795,8 @@ public:
         if (is_valid_isa(avx))
             vmulss(x, op1, op2);
         else {
-            assert(x.isEqualIfNotInherited(op1));
+            if (!x.isEqualIfNotInherited(op1))
+                movss(x, op1);
             mulss(x, op2);
         }
     }

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -1370,6 +1370,15 @@ public:
         vcvttps2dq(x, op);
     }
 
+    void uni_vcvtsi2ss(const Xbyak::Xmm& x1, const Xbyak::Xmm& x2, const Xbyak::Operand& op) {
+        if (is_valid_isa(avx)) {
+            vcvtsi2ss(x1, x2, op);
+        } else {
+            assert(x1.getIdx() == x2.getIdx());
+            cvtsi2ss(x1, op);
+        }
+    }
+
     void uni_vmovmskps(const Xbyak::Reg &x1, const Xbyak::Xmm &x2) {
         movmskps(x1.cvt64(), x2);
     }


### PR DESCRIPTION
# Description

The changes add improvements in jit_generator component:
- 3 operands support in uni_vsubss and uni_vmulss for SSE41 code generation.
- Add uni_vcvtsi2ss() method in jit_generator component to support vcvtsi2ss and cvtsi2ss codes generation.