### PR TITLE
Add uni_vhsubps and uni_vaddsubps into jit_generator

### DIFF
--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -674,7 +674,7 @@ public:
     }
 
     void uni_vhsubps(const Xbyak::Xmm &x, const Xbyak::Xmm &x2,
-             const Xbyak::Operand &op) {
+            const Xbyak::Operand &op) {
         if (is_valid_isa(avx)) {
             vhsubps(x, x2, op);
         } else {
@@ -771,12 +771,12 @@ public:
         vsubps(x, op1, op2);
     }
 
-    void uni_vaddsubps(const Xbyak::Xmm &x, const Xbyak::Operand& op1,
-             const Xbyak::Operand &op2) {
+    void uni_vaddsubps(const Xbyak::Xmm &x, const Xbyak::Operand &op1,
+            const Xbyak::Operand &op2) {
         if (is_valid_isa(avx)) {
             vaddsubps(x, op1, op2);
         } else {
-            if (!x.isEqualIfNotInherited(op1)) movups(x, op1);
+            if (!x.isEqualIfNotInherited(op1)) { movups(x, op1); }
             addsubps(x, op2);
         }
     }

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -668,7 +668,9 @@ public:
         if (is_valid_isa(avx)) {
             vhaddps(x, x2, op);
         } else {
-            assert(x.isEqualIfNotInherited(op));
+            if (!x.isEqualIfNotInherited(x2)) {
+                movups(x, x2);
+            }
             haddps(x, op);
         }
     }
@@ -678,7 +680,9 @@ public:
         if (is_valid_isa(avx)) {
             vhsubps(x, x2, op);
         } else {
-            assert(x.isEqualIfNotInherited(op));
+            if (!x.isEqualIfNotInherited(x2)) {
+                movups(x, x2);
+            }
             hsubps(x, op);
         }
     }

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -771,7 +771,7 @@ public:
         vsubps(x, op1, op2);
     }
 
-    void uni_vaddsubps(const Xbyak::Xmm &x, const Operand& op1,
+    void uni_vaddsubps(const Xbyak::Xmm &x, const Xbyak::Operand& op1,
              const Xbyak::Operand &op2) {
         if (is_valid_isa(avx)) {
             vaddsubps(x, op1, op2);

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -674,7 +674,7 @@ public:
     }
 
     void uni_vhsubps(const Xbyak::Xmm &x, const Xbyak::Xmm &x2,
-            const Xbyak::Operand &op) {
+                     const Xbyak::Operand &op) {
         if (is_valid_isa(avx)) {
             vhsubps(x, x2, op);
         } else {
@@ -772,11 +772,13 @@ public:
     }
 
     void uni_vaddsubps(const Xbyak::Xmm &x, const Xbyak::Operand &op1,
-            const Xbyak::Operand &op2) {
+                       const Xbyak::Operand &op2) {
         if (is_valid_isa(avx)) {
             vaddsubps(x, op1, op2);
         } else {
-            if (!x.isEqualIfNotInherited(op1)) { movups(x, op1); }
+            if (!x.isEqualIfNotInherited(op1)) {
+                movups(x, op1);
+            }
             addsubps(x, op2);
         }
     }

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -673,6 +673,16 @@ public:
         }
     }
 
+    void uni_vhsubps(const Xbyak::Xmm &x, const Xbyak::Xmm &x2,
+             const Xbyak::Operand &op) {
+        if (is_valid_isa(avx)) {
+            vhsubps(x, x2, op);
+        } else {
+            assert(x.isEqualIfNotInherited(op));
+            hsubps(x, op);
+        }
+    }
+
     void uni_vpsignd(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
             const Xbyak::Operand &op) {
         if (is_valid_isa(avx))
@@ -759,6 +769,16 @@ public:
     void uni_vsubps(const Xbyak::Ymm &x, const Xbyak::Operand &op1,
             const Xbyak::Operand &op2, const Xbyak::Ymm &buf) {
         vsubps(x, op1, op2);
+    }
+
+    void uni_vaddsubps(const Xbyak::Xmm &x, const Operand& op1,
+             const Xbyak::Operand &op2) {
+        if (is_valid_isa(avx)) {
+            vaddsubps(x, op1, op2);
+        } else {
+            if (!x.isEqualIfNotInherited(op1)) movups(x, op1);
+            addsubps(x, op2);
+        }
     }
 
     void uni_vpmulld(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,


### PR DESCRIPTION
# Description

Add VEX / non-VEX switch functions for hsubps and addsubps instructions into jit_generator component.

OpenVINO PR:
- https://github.com/openvinotoolkit/openvino/pull/11946)