### PR TITLE
Add missing uni_vmovdqu operation overload for AVX-512

### DIFF
--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -1473,6 +1473,14 @@ public:
         vtestps(x1, op);
     }
 
+    void uni_vucomiss(const Xbyak::Xmm &x, const Xbyak::Operand &op) {
+        if (is_valid_isa(avx)) {
+            vucomiss(x, op);
+        } else {
+            ucomiss(x, op);
+        }
+    }
+
     void uni_vblendvps(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
             const Xbyak::Operand &op, const Xbyak::Xmm &msk) {
         if (is_valid_isa(avx))
@@ -1499,6 +1507,22 @@ public:
             blendps(x1, op, imm);
         }
     }
+
+    void uni_vpblendw(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
+                      const Xbyak::Operand &op, const int imm) {
+        assert(!x1.isZMM() && !x2.isZMM());
+
+        if (is_valid_isa(avx))
+            vpblendw(x1, x2, op, imm);
+        else {
+            assert(x1.getIdx() == x2.getIdx());
+            pblendw(x1, op, imm);
+        }
+    }
+
+    // NOTE: Add in future support for Zmm registers if there will be appropriate instruction
+    void uni_vpblendw(const Xbyak::Zmm &x1, const Xbyak::Zmm &x2,
+                      const Xbyak::Operand &op, const int imm) = delete;
 
     void uni_vroundps(
             const Xbyak::Xmm &x, const Xbyak::Operand &op, const int imm) {

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -469,6 +469,10 @@ public:
         vmovdqu32(x, addr);
     }
 
+    void uni_vmovdqu(const Xbyak::Zmm &x1, const Xbyak::Zmm &x2) {
+        vmovdqu32(x1, x2);
+    }
+
     void uni_vmovups(const Xbyak::Address &addr, const Xbyak::Xmm &x) {
         if (is_valid_isa(avx))
             vmovups(addr, x);


### PR DESCRIPTION
# Description

This change unbreak uni_vmovdqu() function resolution for reg <- reg scheme on AVX-512.
Other overloads have only reg <- addr and addr <- reg schemes plus one for xmm <- xmm register move - but, for the last, operation is invalid for AVX-512.
Add special overload for zmm registers to resolve 'invalid instruction' errors in runtime.

The test case was attached to Interpolate-4 PR: https://github.com/openvinotoolkit/openvino/pull/12771/commits/42136687262aa78834ce8dcdd20c67f207be7d42

While here, add VEX / non-VEX switch functions for vpblendw and vucomiss instructions into jit_generator component - they are required too for Interpolate-4 PR.

OpenVINO PR:
- https://github.com/openvinotoolkit/openvino/pull/12771