### PR TITLE
Add support for exceptions during code generation

### DIFF
--- a/src/cpu/x64/cpu_isa_traits.hpp
+++ b/src/cpu/x64/cpu_isa_traits.hpp
@@ -34,7 +34,9 @@
 //#define XBYAK_USE_MMAP_ALLOCATOR
 /* Use Xbyak's memfd-based allocation, if available */
 #define XBYAK_USE_MEMFD
+#ifndef DNNL_ENABLE_EXCEPTIONS
 #define XBYAK_NO_EXCEPTION
+#endif
 #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 /* turn off `size_t to other-type implicit casting` warning
  * currently we have a lot of jit-generated instructions that


### PR DESCRIPTION
# Description
This PR allows exceptions during code generation

# Motivation
Consider the following code:
```cpp
    ...
    template <x64::cpu_isa_t isa>
    void jit_refine_anchors_kernel_fp32<isa>::generate() {
        ...
        vpextrd(val.cvt32(), ymm_val, i);
        ...
    }
    ...
    status_t create_kernel() override {
        const status_t code = jit_generator::create_kernel();
        if (code != dnnl::impl::status::success) {
            IE_THROW() << "Could not create kernel. Error code: " << std::to_string(code) << ". " <<
                          "Xbyak error code: " << Xbyak::ConvertErrorToString(Xbyak::GetError());
        }
        kernel_ = reinterpret_cast<decltype(kernel_)>(jit_ker());
        return code;
    }
    ...
```
We would see the error during code generation `const status_t code = jit_generator::create_kernel();` that is sounds like `bad combination`, but it is not obvious where is an error code.
If we allow exceptions, then in line `vpextrd(val.cvt32(), ymm_val, i);` will be thrown an exception with error `bad combination` and it makes obvious that it happens due to wrong register type `Ymm` instead of `Xmm` (`vpextrd` is working with `Xmm` registers)

Corresponding openvino PR https://github.com/openvinotoolkit/openvino/pull/13672