### PR TITLE
fix bug when multiple eltwise postOps of same algo exist and runtime output scales in execute_forward_3d_dw

### DIFF
--- a/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
@@ -56,9 +56,11 @@ jit_uni_postops_injector_t<isa, Vmm>::jit_uni_postops_injector_t(
     const auto &esp = eltwise_static_params;
     const auto &qsp = quantization_static_params;
 
-    for (const auto &post_op : post_ops.entry_) {
+    for (int i = 0; i < post_ops_.len(); i++) {
+        const auto &post_op = post_ops_.entry_[i];
+
         if (post_op.is_eltwise()) {
-            alg_to_eltwise_injector_.emplace(post_op.eltwise.alg,
+            alg_to_eltwise_injector_.emplace(i,
                                              jit_uni_eltwise_injector_f32<isa, Vmm>(host_, post_op.eltwise,
                                                                                esp.save_state, esp.p_table, esp.k_mask, esp.is_fwd,
                                                                                esp.use_dst));
@@ -94,10 +96,12 @@ jit_uni_postops_injector_t<isa, Vmm>::jit_uni_postops_injector_t(
     bool is_binary = false;
     bool is_eltwise = false;
 
-    for (const auto &post_op : post_ops.entry_) {
+    for (int i = 0; i < post_ops_.len(); i++) {
+        const auto &post_op = post_ops_.entry_[i];
+
         if (post_op.is_eltwise()) {
             is_eltwise = true;
-            alg_to_eltwise_injector_.emplace(post_op.eltwise.alg,
+            alg_to_eltwise_injector_.emplace(i,
                     jit_uni_eltwise_injector_f32<isa, Vmm>(host_,
                             post_op.eltwise, esp.save_state, esp.p_table,
                             esp.k_mask, esp.is_fwd, esp.use_dst,
@@ -222,7 +226,7 @@ void jit_uni_postops_injector_t<isa, Vmm>::compute_vector_range(
         const auto &post_op = post_ops_.entry_[i];
 
         if (post_op.is_eltwise()) {
-            alg_to_eltwise_injector_.at(post_op.eltwise.alg)
+            alg_to_eltwise_injector_.at(i)
                     .compute_vector_range(vmm_idxs);
         } else if (post_op.is_binary()) {
             binary_injector_->compute_vector_range(

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
@@ -161,7 +161,7 @@ public:
 private:
     post_ops_t post_ops_;
     jit_generator *host_;
-    std::map<dnnl::impl::alg_kind_t, jit_uni_eltwise_injector_f32<isa, Vmm>>
+    std::map<int, jit_uni_eltwise_injector_f32<isa, Vmm>>
             alg_to_eltwise_injector_;
     std::unique_ptr<binary_injector::jit_uni_binary_injector_t<isa, Vmm>>
             binary_injector_;

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
@@ -247,6 +247,11 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::apply_postops(const Zmm zmm_out,
         }
 
         postops_injector_->compute_vector_range({(size_t)vmm_idx}, rhs_arg_params, ddp, qdp);
+
+        if ((jcp.with_depthwise || jcp.with_quantization) && jcp.src_zero_point) {
+            // restore reg_zp_compensation register which was overwritten by legacy postOps
+            mov(reg_zp_compensation, ptr[param1 + GET_OFF(zp_compensation)]);
+        }
     }
 }
 

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -1400,6 +1400,11 @@ void jit_avx512_core_amx_fwd_kernel_t::apply_postops(const Zmm &zmm_out,
         }
 
         postops_injector_->compute_vector_range({(size_t)vmm_idx}, rhs_arg_params, ddp, qdp);
+
+        if ((jcp.with_depthwise || jcp.with_quantization) && jcp.src_zero_point) {
+            // restore reg_zp_compensation register which was overwritten by legacy postOps
+            mov(reg_zp_compensation, ptr[param1 + GET_OFF(zp_compensation)]);
+        }
     }
 }
 

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -2564,7 +2564,31 @@ public:
     virtual const char *name() const = 0;
     virtual const char *source_file() const = 0;
 
+    void dump_debug_traces(const uint8_t *code, size_t code_size) const {
+#if !defined(NDEBUG) && defined(__GNUC__)
+        if (code && get_jit_dump()) {
+        #define MAX_FNAME_LEN 256
+            static int counter = 0;
+            char fname[MAX_FNAME_LEN + 1];
+            snprintf(fname, MAX_FNAME_LEN, "dnnl_traces_cpu_%s.%d.txt", name(),
+                    counter);
+            counter++;
+
+            std::cout << "[ oneDNN ] dump_debug_traces: " << fname << std::endl;
+            FILE *fp = fopen(fname, "wb+");
+            if (fp) {
+                for (const auto & p : get_debug_traces()) {
+                    fprintf(fp, "%lx:\t%s\n", p.first, p.second.c_str());
+                }
+                fclose(fp);
+            }
+        #undef MAX_FNAME_LEN
+        }
+#endif
+    }
+
     void register_jit_code(const Xbyak::uint8 *code, size_t code_size) const {
+        dump_debug_traces(code, code_size);
         jit_utils::register_jit_code(code, code_size, name(), source_file());
     }
 

--- a/src/cpu/x64/jit_uni_x8s8s32x_convolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_convolution.cpp
@@ -719,20 +719,10 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_3d_dw(const ex
     assert(jcp.nb_oc_blocking == 1);
     assert(jcp.nb_ch % jcp.nb_ch_blocking == 0);
 
-    const float *oscales = pd()->attr()->output_scales_.scales_;
-    if (jcp.signed_input && !jcp.has_vnni) {
-        auto local_scales = ctx.get_scratchpad_grantor().template get<float>(
-                key_conv_adjusted_scales);
-        size_t count = pd()->attr()->output_scales_.count_;
-        float factor = 1.f / pd()->jcp_.wei_adj_scale;
-        if (count == 1) {
-            utils::array_set(local_scales, oscales[0] * factor, 16);
-        } else {
-            for (size_t c = 0; c < count; c++)
-                local_scales[c] = oscales[c] * factor;
-        }
-        oscales = local_scales;
-    }
+    DEFINE_SCALES_BUFFER(oscales);
+
+    if (jcp.signed_input && (!jcp.has_vnni))
+        oscales = adjust_oscales(ctx.get_scratchpad_grantor(), oscales);
 
     size_t offset = weights_d.size() - weights_d.additional_buffer_size();
     auto w = const_cast<char *>(weights);


### PR DESCRIPTION
# Description

openvino PR: [PR13502](https://github.com/openvinotoolkit/openvino/pull/13502)


- eltwise injectors of one primitive are maintained in C++ map using alg as key, when multiple eltwise postOps of same algorithm with different compile-time arguments are appended, only the projector of last one exist in the map, this would generate incorrect code. replace the key with index in postOps array fixed the issue.

 - our custom kernel `jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_3d_dw` doesn't support runtime output scales which required by PR13502, this change adds supports to it.

- in jit_avx512_core_amx kernels, when source zero point exists together with legacy postOps, restore reg_zp_compensation register which was overwritten by legacy postOps. 

- added jit debug trace dump utility in GCC DEBUG mode for easier jit code debug.
 
# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
