### PR TITLE
Fix seg fault in parallel function with ITT build

### DIFF
--- a/src/common/dnnl_thread.cpp
+++ b/src/common/dnnl_thread.cpp
@@ -1,0 +1,101 @@
+#include <functional>
+
+#include "dnnl_thread.hpp"
+
+#if defined(DNNL_ENABLE_ITT_TASKS)
+#include "common/ittnotify.hpp"
+#endif
+
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+#include "counting_barrier.hpp"
+#endif
+
+namespace dnnl {
+namespace impl {
+
+void parallel(int nthr, const std::function<void(int, int)> &f) {
+    nthr = adjust_num_threads(nthr, INT64_MAX);
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_SEQ
+    assert(nthr == 1);
+    f(0, 1);
+#else
+#if defined(DNNL_ENABLE_ITT_TASKS)
+    auto task_primitive_kind = itt::primitive_task_get_current_kind();
+    bool itt_enable = itt::get_itt(itt::__itt_task_level_high);
+#endif
+    if (nthr == 1) {
+        f(0, 1);
+        return;
+    }
+#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
+#pragma omp parallel num_threads(nthr)
+    {
+        int nthr_ = omp_get_num_threads();
+        int ithr_ = omp_get_thread_num();
+        assert(nthr_ == nthr);
+#if defined(DNNL_ENABLE_ITT_TASKS)
+        if (ithr_ && itt_enable) itt::primitive_task_start(task_primitive_kind);
+#endif
+        f(ithr_, nthr_);
+#if defined(DNNL_ENABLE_ITT_TASKS)
+        if (ithr_ && itt_enable) itt::primitive_task_end();
+#endif
+    }
+#elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_TBB
+    tbb::parallel_for(
+            0, nthr,
+            [=](int ithr) {
+#if defined(DNNL_ENABLE_ITT_TASKS)
+                bool mark_task = itt::primitive_task_get_current_kind()
+                        == primitive_kind::undefined;
+                if (mark_task && itt_enable)
+                    itt::primitive_task_start(task_primitive_kind);
+#endif
+                f(ithr, nthr);
+#if defined(DNNL_ENABLE_ITT_TASKS)
+                if (mark_task && itt_enable) itt::primitive_task_end();
+#endif
+            },
+            tbb::static_partitioner());
+#elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_TBB_AUTO
+    tbb::parallel_for(
+            0, nthr, [&](int ithr) { f(ithr, nthr); });
+#elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+    using namespace dnnl::impl::threadpool_utils;
+    dnnl::threadpool_interop::threadpool_iface *tp = get_active_threadpool();
+    if (!tp || dnnl_in_parallel()) {
+        threadpool_utils::deactivate_threadpool();
+        for (int ithr = 0; ithr < nthr; ithr++) {
+            f(ithr, nthr);
+        }
+        threadpool_utils::activate_threadpool(tp);
+    } else {
+        bool async = tp->get_flags()
+                & dnnl::threadpool_interop::threadpool_iface::ASYNCHRONOUS;
+        counting_barrier_t b;
+        if (async) b.init(nthr);
+        tp->parallel_for(nthr, [&, tp](int ithr, int nthr) {
+            bool is_master = threadpool_utils::get_active_threadpool() == tp;
+            if (!is_master) {
+                threadpool_utils::activate_threadpool(tp);
+#if defined(DNNL_ENABLE_ITT_TASKS)
+                if (itt_enable) itt::primitive_task_start(task_primitive_kind);
+#endif
+            }
+            f(ithr, nthr);
+            if (!is_master) {
+#if defined(DNNL_ENABLE_ITT_TASKS)
+                if (itt_enable) itt::primitive_task_end();
+#endif
+                threadpool_utils::deactivate_threadpool();
+            }
+            if (async) b.notify();
+        });
+        if (async) b.wait();
+    }
+#endif
+#endif
+}
+
+} // namespace impl
+} // namespace dnnl

--- a/src/common/dnnl_thread.hpp
+++ b/src/common/dnnl_thread.hpp
@@ -298,87 +298,7 @@ inline int adjust_num_threads(int nthr, dim_t work_amount) {
 #endif
 }
 
-inline void parallel(int nthr, const std::function<void(int, int)> &f) {
-    nthr = adjust_num_threads(nthr, INT64_MAX);
-#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_SEQ
-    for (int i = 0; i < nthr; ++i) {
-        f(i, nthr);
-    }
-#else
-#if defined(DNNL_ENABLE_ITT_TASKS)
-    auto task_primitive_kind = itt::primitive_task_get_current_kind();
-    bool itt_enable = itt::get_itt(itt::__itt_task_level_high);
-#endif
-    if (nthr == 1) {
-        f(0, 1);
-        return;
-    }
-#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
-#pragma omp parallel num_threads(nthr)
-    {
-        int nthr_ = omp_get_num_threads();
-        int ithr_ = omp_get_thread_num();
-        assert(nthr_ == nthr);
-#if defined(DNNL_ENABLE_ITT_TASKS)
-        if (ithr_ && itt_enable) itt::primitive_task_start(task_primitive_kind);
-#endif
-        f(ithr_, nthr_);
-#if defined(DNNL_ENABLE_ITT_TASKS)
-        if (ithr_ && itt_enable) itt::primitive_task_end();
-#endif
-    }
-#elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_TBB
-    tbb::parallel_for(
-            0, nthr,
-            [&](int ithr) {
-#if defined(DNNL_ENABLE_ITT_TASKS)
-                bool mark_task = itt::primitive_task_get_current_kind()
-                        == primitive_kind::undefined;
-                if (mark_task && itt_enable)
-                    itt::primitive_task_start(task_primitive_kind);
-#endif
-                f(ithr, nthr);
-#if defined(DNNL_ENABLE_ITT_TASKS)
-                if (mark_task && itt_enable) itt::primitive_task_end();
-#endif
-            },
-            tbb::static_partitioner());
-#elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
-    using namespace dnnl::impl::threadpool_utils;
-    dnnl::threadpool_interop::threadpool_iface *tp = get_active_threadpool();
-    if (!tp || dnnl_in_parallel()) {
-        threadpool_utils::deactivate_threadpool();
-        for (int ithr = 0; ithr < nthr; ithr++) {
-            f(ithr, nthr);
-        }
-        threadpool_utils::activate_threadpool(tp);
-    } else {
-        bool async = tp->get_flags()
-                & dnnl::threadpool_interop::threadpool_iface::ASYNCHRONOUS;
-        counting_barrier_t b;
-        if (async) b.init(nthr);
-        tp->parallel_for(nthr, [&, tp](int ithr, int nthr) {
-            bool is_master = threadpool_utils::get_active_threadpool() == tp;
-            if (!is_master) {
-                threadpool_utils::activate_threadpool(tp);
-#if defined(DNNL_ENABLE_ITT_TASKS)
-                if (itt_enable) itt::primitive_task_start(task_primitive_kind);
-#endif
-            }
-            f(ithr, nthr);
-            if (!is_master) {
-#if defined(DNNL_ENABLE_ITT_TASKS)
-                if (itt_enable) itt::primitive_task_end();
-#endif
-                threadpool_utils::deactivate_threadpool();
-            }
-            if (async) b.notify();
-        });
-        if (async) b.wait();
-    }
-#endif
-#endif
-}
+void DNNL_API parallel(int nthr, const std::function<void(int, int)> &f);
 
 /* for_nd section */
 inline void for_nd(const int ithr, const int nthr, dim_t D0,
@@ -678,82 +598,82 @@ void parallel_legacy(int nthr, F f) {
     nthr = adjust_num_threads(nthr, INT64_MAX);
 #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_SEQ
     assert(nthr == 1);
-f(0, 1);
+    f(0, 1);
 #else
 #if defined(DNNL_ENABLE_ITT_TASKS)
     auto task_primitive_kind = itt::primitive_task_get_current_kind();
-bool itt_enable = itt::get_itt(itt::__itt_task_level_high);
+    bool itt_enable = itt::get_itt(itt::__itt_task_level_high);
 #endif
     if (nthr == 1) {
         f(0, 1);
         return;
     }
 #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
-    #pragma omp parallel num_threads(nthr)
-{
-int nthr_ = omp_get_num_threads();
-int ithr_ = omp_get_thread_num();
-assert(nthr_ == nthr);
+#pragma omp parallel num_threads(nthr)
+    {
+        int nthr_ = omp_get_num_threads();
+        int ithr_ = omp_get_thread_num();
+        assert(nthr_ == nthr);
 #if defined(DNNL_ENABLE_ITT_TASKS)
-if (ithr_ && itt_enable) itt::primitive_task_start(task_primitive_kind);
+        if (ithr_ && itt_enable) itt::primitive_task_start(task_primitive_kind);
 #endif
-f(ithr_, nthr_);
+        f(ithr_, nthr_);
 #if defined(DNNL_ENABLE_ITT_TASKS)
-if (ithr_ && itt_enable) itt::primitive_task_end();
+        if (ithr_ && itt_enable) itt::primitive_task_end();
 #endif
-}
+    }
 #elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_TBB
     tbb::parallel_for(
-            0, nthr,
-            [&](int ithr) {
+        0, nthr,
+        [&](int ithr) {
 #if defined(DNNL_ENABLE_ITT_TASKS)
-                bool mark_task = itt::primitive_task_get_current_kind()
-            == primitive_kind::undefined;
-    if (mark_task && itt_enable)
-        itt::primitive_task_start(task_primitive_kind);
+            bool mark_task = itt::primitive_task_get_current_kind()
+                == primitive_kind::undefined;
+            if (mark_task && itt_enable)
+                itt::primitive_task_start(task_primitive_kind);
 #endif
-                f(ithr, nthr);
+            f(ithr, nthr);
 #if defined(DNNL_ENABLE_ITT_TASKS)
-                if (mark_task && itt_enable) itt::primitive_task_end();
+            if (mark_task && itt_enable) itt::primitive_task_end();
 #endif
-            },
-            tbb::static_partitioner());
+        },
+        tbb::static_partitioner());
 #elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_TBB_AUTO
     tbb::parallel_for(
-0, nthr, [&](int ithr) { f(ithr, nthr); });
+        0, nthr, [&](int ithr) { f(ithr, nthr); });
 #elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
-using namespace dnnl::impl::threadpool_utils;
-dnnl::threadpool_interop::threadpool_iface *tp = get_active_threadpool();
-if (!tp || dnnl_in_parallel()) {
-threadpool_utils::deactivate_threadpool();
-for (int ithr = 0; ithr < nthr; ithr++) {
-f(ithr, nthr);
-}
-threadpool_utils::activate_threadpool(tp);
-} else {
-bool async = tp->get_flags()
-    & dnnl::threadpool_interop::threadpool_iface::ASYNCHRONOUS;
-counting_barrier_t b;
-if (async) b.init(nthr);
-tp->parallel_for(nthr, [&, tp](int ithr, int nthr) {
-bool is_master = threadpool_utils::get_active_threadpool() == tp;
-if (!is_master) {
-    threadpool_utils::activate_threadpool(tp);
+    using namespace dnnl::impl::threadpool_utils;
+    dnnl::threadpool_interop::threadpool_iface *tp = get_active_threadpool();
+    if (!tp || dnnl_in_parallel()) {
+        threadpool_utils::deactivate_threadpool();
+        for (int ithr = 0; ithr < nthr; ithr++) {
+            f(ithr, nthr);
+        }
+        threadpool_utils::activate_threadpool(tp);
+    } else {
+        bool async = tp->get_flags()
+            & dnnl::threadpool_interop::threadpool_iface::ASYNCHRONOUS;
+        counting_barrier_t b;
+        if (async) b.init(nthr);
+        tp->parallel_for(nthr, [&, tp](int ithr, int nthr) {
+            bool is_master = threadpool_utils::get_active_threadpool() == tp;
+            if (!is_master) {
+                threadpool_utils::activate_threadpool(tp);
 #if defined(DNNL_ENABLE_ITT_TASKS)
-    if (itt_enable) itt::primitive_task_start(task_primitive_kind);
+                if (itt_enable) itt::primitive_task_start(task_primitive_kind);
 #endif
-}
-f(ithr, nthr);
-if (!is_master) {
+            }
+            f(ithr, nthr);
+            if (!is_master) {
 #if defined(DNNL_ENABLE_ITT_TASKS)
-    if (itt_enable) itt::primitive_task_end();
+                if (itt_enable) itt::primitive_task_end();
 #endif
-    threadpool_utils::deactivate_threadpool();
-}
-if (async) b.notify();
-});
-if (async) b.wait();
-}
+                threadpool_utils::deactivate_threadpool();
+            }
+            if (async) b.notify();
+        });
+        if (async) b.wait();
+    }
 #endif
 #endif
 }


### PR DESCRIPTION
### Details:
- openvino PR - https://github.com/openvinotoolkit/openvino/pull/14048
- Inline and gcc optimizations lead to crash in parallel function.
Workaround is to move 'parallel' implementation back to cpp file.
- not reproduced with gcc-10 and gcc-11
### Tickets:
- 95601