### PR TITLE
Extend AMX deconv to support oscale+eltwise+eltwise post ops.

### DIFF
--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -3217,7 +3217,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_bf16(
     }
 
     const int eltwise_ind = p.find(primitive_kind::eltwise);
-    if (eltwise_ind != -1) eltwise_injector_->compute_vector(zmm_out.getIdx());
+    if (eltwise_ind != -1) idx_to_eltwise_injector_.at(eltwise_ind).compute_vector(zmm_out.getIdx());
 
     if (jcp.dsrc_dt == data_type::bf16) {
         Ymm ymm_out = Ymm(zmm_out.getIdx());
@@ -3268,7 +3268,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_int8(
             EVEX_compress_addr(reg_ptr_scales, scale_offset));
 
     /* Do post-ops */
-    if (maybe_eltwise(0)) eltwise_injector_->compute_vector(zmm_out.getIdx());
+    if (maybe_eltwise(0)) idx_to_eltwise_injector_.at(0).compute_vector(zmm_out.getIdx());
     if (p_sum_scale) { // post_op: sum
         cvt2ps(jcp.dsrc_dt, zmm_prev_dst, addr, mask_flag);
         if (*p_sum_zp != 0) {
@@ -3280,8 +3280,11 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_int8(
         else
             vfmadd231ps(zmm_out, zmm_prev_dst, zword_b[reg_ptr_sum_scale]);
     }
-    if (maybe_eltwise(1)) eltwise_injector_->compute_vector(zmm_out.getIdx());
-
+    if (maybe_eltwise(1)) idx_to_eltwise_injector_.at(1).compute_vector(zmm_out.getIdx());
+    for (auto i = 2; i < jcp.post_ops.len(); i++) {
+        if (idx_to_eltwise_injector_.count(i) != 0)
+            idx_to_eltwise_injector_.at(i).compute_vector(zmm_out.getIdx());
+    }
     // Properly saturate the accumulators for integer datatypes
     if (one_of(jcp.dsrc_dt, u8, s8, s32)) {
         init_saturate_f32(
@@ -3604,7 +3607,10 @@ void jit_avx512_core_amx_bwd_data_kernel_t::generate() {
 
     postamble();
 
-    if (jcp.with_eltwise) eltwise_injector_->prepare_table();
+    if (jcp.with_eltwise) {
+        for (auto &elt_injector : idx_to_eltwise_injector_)
+            elt_injector.second.prepare_table();
+    }
 }
 
 bool jit_avx512_core_amx_bwd_data_kernel_t::post_ops_ok(
@@ -3621,6 +3627,12 @@ bool jit_avx512_core_amx_bwd_data_kernel_t::post_ops_ok(
         else
             return p.contain(sum, idx);
     };
+    //Add more element-wise post-ops supported for int8 deconv.
+    bool all_eltwise = jcp.is_int8_deconvolution;
+    for (auto i = 0; i < p.len(); i++)
+        all_eltwise &= is_eltwise(i);
+    if (all_eltwise)
+        return true;
 
     switch (p.len()) {
         case 0: return true;
@@ -3690,7 +3702,7 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
             one_of(diff_src_d.data_type(), bf16, f32));
     const bool is_bf16_convolution = is_bf16 && !is_deconv;
     const bool is_bf16_deconvolution = is_bf16 && is_deconv;
-    const bool is_int8_deconvolution = is_deconv
+    const bool is_int8_deconvolution  = is_deconv
             && everyone_is(true, one_of(diff_dst_d.data_type(), s8, u8),
                     weights_d.data_type() == s8,
                     one_of(diff_src_d.data_type(), f32, s32, s8, u8));
@@ -3700,6 +3712,7 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     if (!supported) return status::unimplemented;
 
     jcp = zero<decltype(jcp)>();
+    jcp.is_int8_deconvolution = is_int8_deconvolution;
     jcp.isa = is_bf16 ? avx512_core_bf16_amx_bf16 : avx512_core_bf16_amx_int8;
     jcp.ndims = ndims;
     jcp.prop_kind = cd.prop_kind;
@@ -3784,7 +3797,7 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
         return status::unimplemented;
 
     jcp.is_nspc = jcp.src_tag == dat_tag_nspc;
-    assert(IMPLICATION(is_int8_deconvolution, jcp.is_nspc));
+    assert(IMPLICATION(jcp.is_int8_deconvolution, jcp.is_nspc));
 
     // TODO: remove all support for nChw16c from this implementation
     if (!jcp.is_nspc) return status::unimplemented;
@@ -3822,7 +3835,7 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     const auto &p = attr.post_ops_;
     const int eltwise_ind = p.find(primitive_kind::eltwise);
     jcp.with_eltwise = eltwise_ind != -1;
-    if (jcp.with_eltwise) jcp.eltwise = p.entry_[eltwise_ind].eltwise;
+    jcp.post_ops = p;
 
     auto set_or_check_wei_format = [&]() {
         using namespace format_tag;
@@ -3835,7 +3848,7 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
             wei_tag = pick(with_groups + 2 * (ndims - 3), OIw16i16o2i,
                     gOIw16i16o2i, OIhw16i16o2i, gOIhw16i16o2i, OIdhw16i16o2i,
                     gOIdhw16i16o2i);
-        else if (is_int8_deconvolution)
+        else if (jcp.is_int8_deconvolution)
             wei_tag = pick(with_groups + 2 * (ndims - 3), OIw16i16o4i,
                     gOIw16i16o4i, OIhw16i16o4i, gOIhw16i16o4i, OIdhw16i16o4i,
                     gOIdhw16i16o4i);

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.hpp
@@ -485,11 +485,15 @@ struct jit_avx512_core_amx_bwd_data_kernel_t : public jit_generator {
         : jit_generator(
                 jit_name(), nullptr, MAX_CODE_SIZE, true, avx512_core_amx)
         , jcp(ajcp)
-        , attr_(attr)
-        , eltwise_injector_(nullptr) {
-        if (jcp.with_eltwise)
-            eltwise_injector_ = new jit_uni_eltwise_injector_f32<avx512_core>(
-                    this, jcp.eltwise);
+        , attr_(attr) {
+        if (jcp.with_eltwise) {
+                for (int i = 0; i < jcp.post_ops.len(); i++) {
+                        const auto post_op = jcp.post_ops.entry_[i];
+                        if (post_op.is_eltwise())
+                                idx_to_eltwise_injector_.emplace(i,
+                                                        jit_uni_eltwise_injector_f32<avx512_core>(this, post_op.eltwise));
+                }
+        }
         bwd_data_copy_kernel_
                 = new jit_avx512_core_amx_bwd_data_copy_kernel_t(jcp);
     }
@@ -499,7 +503,6 @@ struct jit_avx512_core_amx_bwd_data_kernel_t : public jit_generator {
         return status::success;
     }
     ~jit_avx512_core_amx_bwd_data_kernel_t() {
-        delete eltwise_injector_;
         delete bwd_data_copy_kernel_;
     }
 
@@ -523,7 +526,9 @@ struct jit_avx512_core_amx_bwd_data_kernel_t : public jit_generator {
     }
 
 private:
-    jit_uni_eltwise_injector_f32<avx512_core> *eltwise_injector_;
+    std::map<int, jit_uni_eltwise_injector_f32<avx512_core>>
+            idx_to_eltwise_injector_;
+
     jit_avx512_core_amx_bwd_data_copy_kernel_t *bwd_data_copy_kernel_;
 
     int prv_width_ = 0;

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -423,7 +423,7 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
     static constexpr int bcast_simd = 16;
 
     int sp, sp_block, nb_sp;
-    static int last_ic_block_size;
+    static thread_local int last_ic_block_size;
 
     void get_from_jcp(const jit_brgemm_conv_conf_t &jcp) { *this = jcp; }
     void save_to_jcp(jit_brgemm_conv_conf_t &jcp) const { jcp = *this; }
@@ -494,7 +494,7 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
 unsigned brg_blocking_t::L1;
 unsigned brg_blocking_t::L2;
 unsigned brg_blocking_t::L3;
-int brg_blocking_t::last_ic_block_size;
+thread_local int brg_blocking_t::last_ic_block_size;
 
 float brg_blocking_t::io_k(dim_t src, dim_t wei, dim_t dst, float n, float pk,
         bool is_broadcast, bool is_shared) const {

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -263,6 +263,7 @@ struct jit_conv_conf_t {
 
     int dw_conv_oh, dw_conv_ow;
     data_type_t dw_conv_dst_dt;
+    bool is_int8_deconvolution;
 };
 
 // calculates filter size taking into account dilation


### PR DESCRIPTION
# Description
Extend AMX deconv int8 to support oscale+eltwise+eltwise post ops pattern
https://jira.devtools.intel.com/browse/MFDNN-8869