### PR TITLE
enable jit debug_trace() only when ONEDNN_JIT_DUMP is properly exported

### DIFF
--- a/src/cpu/x64/xbyak/xbyak.h
+++ b/src/cpu/x64/xbyak/xbyak.h
@@ -2712,6 +2712,10 @@ public:
 #if !defined(NDEBUG) && defined(__GNUC__)
 	std::map<size_t, std::string> debug_traces;
 	void debug_trace() {
+		static bool enable_trace = std::getenv("ONEDNN_JIT_DUMP") && atoi(std::getenv("ONEDNN_JIT_DUMP")) != 0;
+		if (!enable_trace)
+			return;
+
 		void *array[8];
 		int size = backtrace(array, 8);
 		char **strings = backtrace_symbols(array, size);


### PR DESCRIPTION
# Description

the jit debug_trace is enabled by default in Debug mode, even when ONEDNN_JIT_DUMP is not exported or is zero, this slows down the model compilation process dramatically, especially when developer is focusing on the code other than JIT, so we added a check on whether a non-zero env ONEDNN_JIT_DUMP is exported to skip debug_trace() callstack symbol collection logic.