### PR TITLE
Disable memfd kernel memory allocation

### DIFF
--- a/src/cpu/x64/cpu_isa_traits.hpp
+++ b/src/cpu/x64/cpu_isa_traits.hpp
@@ -33,7 +33,9 @@
  * be obtained with mmap */
 //#define XBYAK_USE_MMAP_ALLOCATOR
 /* Use Xbyak's memfd-based allocation, if available */
-#define XBYAK_USE_MEMFD
+/* @todo [fork] XBYAK_USE_MEMFD is disabled to get rid of segfaults and std::bad_alloc issues
+ * with kernel memory allocations. The exact root cause should be analysed */
+// #define XBYAK_USE_MEMFD
 #ifdef DNNL_XBYAK_NO_EXCEPTION
 #define XBYAK_NO_EXCEPTION
 #endif


### PR DESCRIPTION
to avoid segfaults and std::bad_alloc issues
XBYAK_USE_MEMFD was also defined in v2.6 branch, but has not have any effect, since there was no such functionality in the corresponding xbyak version.

After migration to v2.7 this macro enables memfd_create logic for kernel memory allocation
Also, there is a change related to the memfd tracking in one of the recent xbyak commits, which unfortunately does not fix the current issues:
- https://github.com/herumi/xbyak/commit/2a265d9d9f713fb4bdbaf33b050a32415537bfb5

ov PR:
- https://github.com/openvinotoolkit/openvino/pull/14358