### PR TITLE
Workaround: CC + Windows + CPU pulgin build failure issue.

### DIFF
--- a/src/cpu/cpu_engine.hpp
+++ b/src/cpu/cpu_engine.hpp
@@ -37,7 +37,10 @@
     impl_list_item_t( \
             impl_list_item_t::type_deduction_helper_t<__VA_ARGS__::pd_t>())
 #define CPU_INSTANCE(...) DNNL_PRIMITIVE_IMPL(CPU_INSTANCE_IMPL, __VA_ARGS__)
-#define CPU_INSTANCE_X64(...) DNNL_X64_ONLY(CPU_INSTANCE(__VA_ARGS__))
+// Expanding DNNL_X64_ONLY in order to fix Conditional Compilation failure on Windows + CPU plugin.
+// DNNL_X64_ONLY == CONCAT2(Z_DO_IF_, DNNL_X64)
+#define CPU_INSTANCE_X64(...) \
+    CONCAT2(Z_DO_IF_, DNNL_X64)(CPU_INSTANCE(__VA_ARGS__))
 #define CPU_INSTANCE_SSE41(...) REG_SSE41_ISA(CPU_INSTANCE(__VA_ARGS__))
 #define CPU_INSTANCE_AVX2(...) REG_AVX2_ISA(CPU_INSTANCE(__VA_ARGS__))
 #define CPU_INSTANCE_AVX512(...) REG_AVX512_ISA(CPU_INSTANCE(__VA_ARGS__))


### PR DESCRIPTION
# Description

For file: src/cpu/cpu_pooling_list.cpp, OpenVINO: Conditonal compilation build fail: error C2059: syntax error: 'nullptr'. This maybe Windows compiler bug, the same code work fine for linux. My workaround is that expanding DNNL_X64_ONLY to CONCAT2(Z_DO_IF_, DNNL_X64), it will work. Actually, DNNL_X64_ONLY == CONCAT2(Z_DO_IF_, DNNL_X64).

# OpenVINO PR
https://github.com/openvinotoolkit/openvino/pull/14589
