### PR TITLE
Update jit_avx512_core_x8s8s32x_conv_kernel.cpp

### DIFF
--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
@@ -1472,10 +1472,6 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel::init_conf(jit_conv_conf_t &jcp,
     jcp.isa = mayiuse(avx512_core_bf16) ? avx512_core_bf16
                                         : bf16_emulation_t::get_isa();
 
-    if (jcp.is_depthwise && is_3d)
-        // NOTE: 3D depthwise is not currently supported here.
-        return status::unimplemented;
-
     jcp.with_input_zp = !attr.input_zero_points_.has_default_values();
     jcp.with_weights_zp = !attr.weights_zero_points_.has_default_values();
 


### PR DESCRIPTION
Delete 3D depthwise unimplemented judgments

# Description

In oneDNN branch v2.4_for_ie_master, the detail commit is https://github.com/openvinotoolkit/oneDNN/commit/10fcf5d4094febe0ad68759fc1718a763023f496 . In src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp file, delete the 3D depthwise unimplemented judgments. BUT these lines are preserved in the latest version v2.7_for_ie_master. 
If these lines are not deleted, some models on the xeon platform will choose to run with a non-avx512 kernel, resulting in performance degradation. Such as JIRA CVS-98185.
