### PR TITLE
fix brgemm inner product inputs with spatial dimensions

### DIFF
--- a/src/cpu/x64/jit_brgemm_inner_product.cpp
+++ b/src/cpu/x64/jit_brgemm_inner_product.cpp
@@ -69,9 +69,9 @@ status_t brgemm_inner_product_fwd_t<isa>::execute_forward(
                     pd()->attr()->post_ops_, ctx);
 
     memory_tracking::grantor_t scratchpad = ctx.get_scratchpad_grantor();
-    const memory_desc_wrapper src_d(pd()->src_md());
+    const memory_desc_wrapper src_d(&pd()->flattened_src_md);
     const memory_desc_wrapper dst_d(pd()->dst_md());
-    const memory_desc_wrapper weights_d(pd()->weights_md(0));
+    const memory_desc_wrapper weights_d(&pd()->flattened_weight_md);
 
     DEFINE_SCALES_BUFFER(oscales);
 


### PR DESCRIPTION
# Description

According to documentation https://oneapi-src.github.io/oneDNN/dev_guide_inner_product.html , inner product should support inputs with spatial dimensions and flatten it into 2D internally, `gemm_inner_product_fwd_t` implementation followed this design by calling `pd()->IC_total_padded()` to derive the flattened IC, but `brgemm_inner_product_fwd_t` didn't, it expect spatial dimension to be all ones (id=ih=iw=1), otherwise would fail, this PR fixes the issue by internally reshape src/weight mds

