### PR TITLE
fix few cases where bf16 output precision is combined with legacy post ops

### DIFF
--- a/src/cpu/ref_convolution.cpp
+++ b/src/cpu/ref_convolution.cpp
@@ -212,8 +212,7 @@ status_t ref_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                 args.ctx = &ctx;
                 args.l_offset = dst_l_off;
                 args.dst_md = pd()->dst_md();
-                ref_post_ops->execute(d, args);
-
+                ref_post_ops->execute(d, args, g*OC + oc);
                 io::store_float_value(dst_d.data_type(), d, dst, dst_off);
             });
 

--- a/src/cpu/x64/jit_avx512_core_bf16cvt.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16cvt.hpp
@@ -116,7 +116,7 @@ private:
     }
 
 public:
-    void init_vcvtneps2bf16() {
+    void init_vcvtneps2bf16(bool preserve_scratch = false) {
         const int selector_int32 =
                 /* qnan input to qnan output (presenrving input bits 0..21) */
                 encode_fixup_selector(
@@ -133,6 +133,8 @@ public:
                 /* pos inf input copied to output */
                 encode_fixup_selector(
                         fixup_input_code_pinf, fixup_output_code_copy_input);
+        if (preserve_scratch)
+            host_->push(scratch_);
 
         host_->xor_(scratch_, scratch_);
         host_->mov(scratch_.cvt32(), 0x1);
@@ -145,6 +147,9 @@ public:
         host_->xor_(scratch_, scratch_);
         host_->mov(scratch_.cvt32(), selector_int32);
         host_->vpbroadcastd(selector_, scratch_.cvt32());
+
+        if (preserve_scratch)
+            host_->pop(scratch_);
     }
 
     static cpu_isa_t get_isa() { return avx512_core; }

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -476,8 +476,11 @@ void _jit_avx512_core_x8s8s32x_1x1_conv_kernel<Vmm>::reduce_loop(
             }
         }
 
-        if (jcp.dst_dt == data_type::bf16 && !isa_has_bf16(jcp.isa))
-            bf16_emu_->init_vcvtneps2bf16();
+        if (jcp.dst_dt == data_type::bf16 && !isa_has_bf16(jcp.isa)) {
+            // bf16_emu_reserv_4 is used as reg_oc_off in these postOps
+            bool preserve_scrach = jcp.with_depthwise || jcp.with_quantization;
+            bf16_emu_->init_vcvtneps2bf16(preserve_scrach);
+        }
 
         // store to the destination
         if (jcp.dst_dt == data_type::bf16 && isa_has_bf16(jcp.isa)) {


### PR DESCRIPTION
# Description

 - fixed channel argument passing in `ref_convolution_fwd_t::execute_forward()`, per-OC `legacy-Postops` depending on it
 - fixed `jit_avx512_dw_conv_fwd_kernel_bf16` with per-OC `legacy-Postops`
 - fixed `jit_avx512_core_x8s8s32x_1x1_conv_kernel` with `bf16 emulation` + `legacy-Postops`