### PR TITLE
keep source operation intact on SSE

### DIFF
--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -1614,7 +1614,7 @@ public:
         if (is_valid_isa(avx))
             vpackssdw(x1, x2, op);
         else {
-            assert(x1.getIdx() == x2.getIdx());
+            if (x1.getIdx() != x2.getIdx()) movdqa(x1, x2);
             packssdw(x1, op);
         }
     }
@@ -1628,7 +1628,7 @@ public:
         if (is_valid_isa(avx))
             vpackuswb(x1, x2, op);
         else {
-            assert(x1.getIdx() == x2.getIdx());
+            if (x1.getIdx() != x2.getIdx()) movdqa(x1, x2);
             packuswb(x1, op);
         }
     }
@@ -1642,7 +1642,7 @@ public:
         if (is_valid_isa(avx))
             vpacksswb(x1, x2, op);
         else {
-            assert(x1.getIdx() == x2.getIdx());
+            if (x1.getIdx() != x2.getIdx()) movdqa(x1, x2);
             packsswb(x1, op);
         }
     }
@@ -1906,7 +1906,7 @@ public:
         if (is_valid_isa(avx))
             vpackusdw(x1, x2, op);
         else {
-            assert(x1.getIdx() == x2.getIdx());
+            if (x1.getIdx() != x2.getIdx()) movdqa(x1, x2);
             packusdw(x1, op);
         }
     }


### PR DESCRIPTION
support xxx(dst, src1, src2) on sse, and keep src1 and src2 value intact. Get it work similar like avx2/512 behavior
