### PR TITLE
Fix onednn gemm JIT kernel .

### DIFF
--- a/src/cpu/gemm_x8s8s32x_convolution_utils.hpp
+++ b/src/cpu/gemm_x8s8s32x_convolution_utils.hpp
@@ -57,7 +57,6 @@ protected:
 
     bool do_bias_ = false;
     bool do_scale_ = false;
-    size_t scale_idx_mult_ = 0;
 
     data_type_t bias_data_type_ = data_type::undef;
     data_type_t dst_data_type_ = data_type::undef;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.cpp
@@ -737,6 +737,7 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_3d_dw(const
 
     DEFINE_ARG_SCALES_BUFFER(src_scales, DNNL_ARG_SRC);
     DEFINE_ARG_SCALES_BUFFER(wei_scales, DNNL_ARG_WEIGHTS);
+    DEFINE_ARG_SCALES_BUFFER(dst_scales, DNNL_ARG_DST);
 
     const float *oscales = adjust_oscales(
             ctx.get_scratchpad_grantor(), src_scales, wei_scales);
@@ -802,6 +803,7 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_3d_dw(const
         p.kd_padding = kd_padding;
         p.kh_padding = kh_padding;
         p.scales = scales;
+        p.dst_scale = dst_scales;
         p.f_overflow = i_f_overflow;
         p.back_overflow = i_back_overflow;
         p.t_overflow = i_t_overflow;

--- a/src/cpu/x64/jit_uni_x8s8s32x_convolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_convolution.cpp
@@ -735,6 +735,8 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_3d_dw(const ex
 
     DEFINE_ARG_SCALES_BUFFER(src_scales, DNNL_ARG_SRC);
     DEFINE_ARG_SCALES_BUFFER(wei_scales, DNNL_ARG_WEIGHTS);
+    DEFINE_ARG_SCALES_BUFFER(dst_scales, DNNL_ARG_DST);
+
 
     const float *oscales = adjust_oscales(
             ctx.get_scratchpad_grantor(), src_scales, wei_scales);
@@ -800,6 +802,7 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_3d_dw(const ex
         p.kd_padding = kd_padding;
         p.kh_padding = kh_padding;
         p.scales = scales;
+        p.dst_scale = dst_scales;
         p.f_overflow = i_f_overflow;
         p.back_overflow = i_back_overflow;
         p.t_overflow = i_t_overflow;


### PR DESCRIPTION
# Description

Fix customized pp kernel post process steps to adapt to ONEDNN 3.x changes. Weight scales must be applied before BIAS after ONEDNN 3.X.

[CVS-106536](https://jira.devtools.intel.com/browse/CVS-106536)
