### PR TITLE
[FIX][ARM] Revert v3_2 acl matmul changes

### DIFF
--- a/src/cpu/acl/acl_convolution_utils.cpp
+++ b/src/cpu/acl/acl_convolution_utils.cpp
@@ -552,6 +552,192 @@ status_t acl_init_conf_dw(acl_conv_conf_t &acp, memory_desc_t &src_md,
     return status::success;
 }
 
+status_t acl_init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
+        memory_desc_t &weights_md, memory_desc_t &dst_md,
+        memory_desc_t &bias_md, const convolution_desc_t &cd,
+        const primitive_attr_t &attr) {
+    const memory_desc_wrapper src_d(&src_md);
+    const memory_desc_wrapper wei_d(&weights_md);
+    const memory_desc_wrapper dst_d(&dst_md);
+    const memory_desc_wrapper bia_d(&bias_md);
+
+    acp.fast_math
+            = one_of(attr.fpmath_mode_, fpmath_mode::bf16, fpmath_mode::any);
+
+    // Compute Library currently supports forward propagation only
+    const prop_kind_t prop_kind = cd.prop_kind;
+    const bool is_fwd = (prop_kind == dnnl_forward_training)
+            || (prop_kind == dnnl_forward_inference);
+    if (!is_fwd) return status::unimplemented;
+
+    const int with_groups = wei_d.ndims() == src_d.ndims() + 1;
+    const int ndims = src_d.ndims();
+    const bool is_1d = ndims == 3;
+    const bool is_3d = ndims == 5;
+    bool is_nspc;
+
+    // Compute Library unsupported shape scenarios
+    if (one_of(true, is_3d, is_1d, with_groups)) {
+        return status::unimplemented;
+    }
+
+    // batch size
+    const int mb = src_d.dims()[0];
+
+    // src/input  channels, height, width
+    const int ic = src_d.dims()[1];
+    const int ih = src_d.dims()[ndims - 2];
+    const int iw = src_d.dims()[ndims - 1];
+
+    // dst/output channels, height, width
+    const int oc = dst_d.dims()[1];
+    const int oh = dst_d.dims()[ndims - 2];
+    const int ow = dst_d.dims()[ndims - 1];
+
+    // weights height and width
+    const int kh = wei_d.dims()[with_groups + ndims - 2];
+    const int kw = wei_d.dims()[with_groups + ndims - 1];
+
+    // height and width strides
+    const int stride_h = cd.strides[ndims - 4];
+    const int stride_w = cd.strides[ndims - 3];
+
+    // height and width dilations
+    int dilate_h = cd.dilates[ndims - 4];
+    int dilate_w = cd.dilates[ndims - 3];
+    // oneDNN dilations:          dk = 1 + (k_size - 1) * (dilate_size + 1)
+    // Compute Library dilations: dk = dilate_size * (k_size - 1) + 1
+    // thus acl_dilation = oneDNN_dilation + 1
+    dilate_h += 1;
+    dilate_w += 1;
+
+    acp.dilation_info = arm_compute::Size2D(dilate_w, dilate_h);
+
+    // left, right, top, bottom padding
+    const int l_pad = cd.padding[0][1];
+    const int t_pad = cd.padding[0][0];
+    // Compute Library assumes the padding to be \geq 0, and r(b)_pad may be
+    // equal to -1 in oneDNN for some cases, when the very right (bottom)
+    // spatial elements of the input tensor are not used in the convolution.
+    // On the other hand l(t)_pad are guaranteed to be non-negative.
+    const int r_pad = std::max(static_cast<int>(cd.padding[1][1]), 0);
+    const int b_pad = std::max(static_cast<int>(cd.padding[1][0]), 0);
+
+    acp.padstride_info = arm_compute::PadStrideInfo(stride_w, stride_h,
+            static_cast<unsigned int>(l_pad), static_cast<unsigned int>(r_pad),
+            static_cast<unsigned int>(t_pad), static_cast<unsigned int>(b_pad),
+            arm_compute::DimensionRoundingType::FLOOR);
+
+    acp.with_bias = cd.bias_desc.format_kind != format_kind::undef;
+
+    auto set_or_check_tags = [&](format_tag_t desired_src_tag,
+                                     format_tag_t desired_dst_tag) -> status_t {
+        using namespace format_tag;
+        auto src_tag = any, dst_tag = any;
+
+        if (src_d.format_kind() == format_kind::any) {
+            CHECK(memory_desc_init_by_tag(src_md, desired_src_tag));
+            src_tag = desired_src_tag;
+        } else {
+            src_tag = memory_desc_matches_one_of_tag(src_md, nhwc, nchw);
+        }
+
+        if (dst_d.format_kind() == format_kind::any) {
+            CHECK(memory_desc_init_by_tag(dst_md, desired_dst_tag));
+            dst_tag = desired_dst_tag;
+        } else {
+            dst_tag = memory_desc_matches_one_of_tag(dst_md, nhwc, nchw);
+        }
+
+        if (acp.with_bias && bias_md.format_kind == format_kind::any)
+            CHECK(memory_desc_init_by_tag(bias_md, x));
+
+        is_nspc = utils::one_of(src_tag, nhwc);
+
+        memory_desc_t want_wei_md = weights_md;
+        auto wei_tag = is_nspc ? ohwi : oihw;
+        CHECK(memory_desc_init_by_tag(want_wei_md, wei_tag));
+
+        // Compute Library does not support mismatching layouts
+        if ((src_tag != wei_tag) || (src_tag != dst_tag))
+            return status::unimplemented;
+
+        if (weights_md.format_kind == format_kind::any) {
+            weights_md = want_wei_md;
+        }
+        return (want_wei_md == weights_md) ? status::success
+                                           : status::unimplemented;
+    };
+
+    auto default_dat_tag = format_tag::nhwc;
+    if (set_or_check_tags(default_dat_tag, default_dat_tag) != status::success)
+        return status::unimplemented;
+
+    const auto acl_layout = is_nspc ? arm_compute::DataLayout::NHWC
+                                    : arm_compute::DataLayout::NCHW;
+
+    // For convolutions, int8 datatypes imply quantized types in ACL
+    const auto is_int8 = utils::one_of(src_d.data_type(), s8, u8)
+            && wei_d.data_type() == s8;
+
+    auto acl_src_data_t
+            = acl_utils::get_acl_data_t(src_d.data_type(), is_int8);
+    auto acl_wei_data_t
+            = acl_utils::get_acl_data_t(wei_d.data_type(), is_int8);
+    auto acl_dst_data_t
+            = acl_utils::get_acl_data_t(dst_d.data_type(), is_int8);
+    auto acl_bia_data_t
+            = acl_utils::get_acl_data_t(bia_d.data_type(), is_int8);
+
+    if (acl_bia_data_t == arm_compute::DataType::UNKNOWN)
+        acl_bia_data_t = arm_compute::DataType::F32;
+
+    // clang-format off
+    acp.src_tensor_info = arm_compute::TensorInfo(
+            is_nspc ? arm_compute::TensorShape(ic, iw, ih, mb) :
+            arm_compute::TensorShape(iw, ih, ic, mb),
+            1,
+            acl_src_data_t,
+            acl_layout);
+
+    acp.wei_tensor_info = arm_compute::TensorInfo(
+            is_nspc ? arm_compute::TensorShape(ic, kw, kh, oc) :
+            arm_compute::TensorShape(kw, kh, ic, oc),
+            1,
+            acl_wei_data_t,
+            acl_layout);
+
+    acp.dst_tensor_info = arm_compute::TensorInfo(
+            is_nspc ? arm_compute::TensorShape(oc, ow, oh, mb) :
+            arm_compute::TensorShape(ow, oh, oc, mb),
+            1,
+            acl_dst_data_t,
+            acl_layout);
+
+    acp.bia_tensor_info = arm_compute::TensorInfo(
+            acp.with_bias ? arm_compute::TensorShape(oc)
+                          : arm_compute::TensorShape(),
+            1,
+            acl_bia_data_t,
+            acl_layout);
+    // clang-format on
+
+    // Add quantization info to tensors
+    if (is_int8) {
+        // TODO: Add runtime scales support. Creation time scales will be remove
+        // in 3.0.
+        // const float *scales = attr.output_scales_.scales_;
+        //acp.src_info.set_quantization_info(arm_compute::QuantizationInfo(1, 0));
+        //acp.bia_info.set_quantization_info(arm_compute::QuantizationInfo(1, 0));
+        //acp.wei_info.set_quantization_info(arm_compute::QuantizationInfo(1, 0));
+        //acp.dst_info.set_quantization_info(
+        //       arm_compute::QuantizationInfo(1.0f / scales[0], 0));
+        return status::unimplemented;
+    }
+
+    return status::success;
+}
+
 status_t init_conf_dw(acl_conv_conf_t &acp, memory_desc_t &src_md,
         memory_desc_t &weights_md, memory_desc_t &dst_md,
         memory_desc_t &bias_md, const convolution_desc_t &cd,
@@ -572,6 +758,66 @@ status_t init_conf_dw(acl_conv_conf_t &acp, memory_desc_t &src_md,
         acp.act_info,
         acp.dilation_info));
 
+    // clang-format on
+
+    return status::success;
+}
+
+status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
+        memory_desc_t &weights_md, memory_desc_t &dst_md,
+        memory_desc_t &bias_md, const convolution_desc_t &cd,
+        const primitive_attr_t &attr) {
+
+    // Under these conditions, fallback to faster GEMM-based convolution
+    // unless the user explicitly specifies Winograd algorithm
+    // clang-format off
+    if (one_of(true, src_md.dims[2] > 112, // ih
+                src_md.dims[3] > 112, // iw
+                src_md.dims[1] < 64, // ic
+                dst_md.dims[1] < 64, // oc
+                dnnl_get_max_threads() > 28)
+            && cd.alg_kind == alg_kind::convolution_auto) {
+        return status::unimplemented;
+    }
+    // clang-format on
+
+    // General Compute Library checks, memory tags are also set there
+    CHECK(acl_init_conf_wino(acp, src_md, weights_md, dst_md, bias_md, cd, attr));
+
+    const bool shape_ok
+            // only unit strides allowed
+            = (acp.padstride_info.stride() == std::pair<uint, uint> {1, 1})
+            // Note: Compute Library supports arbitrary padding for wino kernels
+            // but we only allow small padding to be consistent with oneDNN
+            && (acp.padstride_info.pad().first <= 1) // padding left/right
+            && (acp.padstride_info.pad().second <= 1) // padding top/bottom
+            // only non-dilated convolutions allowed
+            && (acp.dilation_info == arm_compute::Size2D(1, 1));
+
+    ACL_CHECK_SUPPORT(!shape_ok, "shape not supported by winograd kernels");
+
+    if (arm_compute::ConvolutionMethod::WINOGRAD !=
+        arm_compute::NEConvolutionLayer::get_convolution_method(&acp.src_tensor_info,
+            &acp.wei_tensor_info,
+            // acp.with_bias ? &acp.bia_tensor_info : nullptr,
+            &acp.dst_tensor_info,
+            acp.padstride_info,
+            arm_compute::WeightsInfo(),
+            acp.dilation_info,
+            acp.act_info,
+            true)) {
+            return status::unimplemented;
+    }
+    // clang-format off
+    // Validate convolution manually to check for return status
+    ACL_CHECK_VALID(arm_compute::NEWinogradConvolutionLayer::validate(
+        &acp.src_tensor_info,
+        &acp.wei_tensor_info,
+        acp.with_bias ? &acp.bia_tensor_info : nullptr,
+        &acp.dst_tensor_info,
+        acp.padstride_info,
+        acp.act_info,
+        true)); // enable_fast_math flag in ACL Winograd
     // clang-format on
 
     return status::success;

--- a/src/cpu/acl/acl_convolution_utils.hpp
+++ b/src/cpu/acl/acl_convolution_utils.hpp
@@ -76,6 +76,10 @@ status_t init_conf_dw(acl_conv_conf_t &acp, memory_desc_t &src_md,
         memory_desc_t &bias_md, const convolution_desc_t &cd,
         const primitive_attr_t &attr);
 
+status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
+        memory_desc_t &weights_md, memory_desc_t &dst_md,
+        memory_desc_t &bias_md, const convolution_desc_t &cd,
+        const primitive_attr_t &attr);
 } // namespace acl_convolution_utils
 
 template <typename conv_obj_t, typename conv_pd_t, typename src_data_t,

--- a/src/cpu/acl/acl_winograd_convolution.cpp
+++ b/src/cpu/acl/acl_winograd_convolution.cpp
@@ -1,0 +1,43 @@
+/*******************************************************************************
+* Copyright 2020-2022 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/acl/acl_winograd_convolution.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace acl {
+
+status_t acl_wino_convolution_fwd_t::execute_forward(
+        const exec_ctx_t &ctx) const {
+    // Lock here is needed because resource_mapper does not support
+    // concurrent multithreaded access.
+    std::lock_guard<std::mutex> _lock {this->mtx};
+    // Retrieve primitive resource and configured Compute Library objects
+    auto *acl_resource
+            = ctx.get_resource_mapper()->get<acl_wino_resource_t>(this);
+    acl_obj_t<arm_compute::NEWinogradConvolutionLayer> &acl_wino_obj
+            = acl_resource->get_acl_obj();
+
+    return execute_forward_conv_acl<
+            acl_obj_t<arm_compute::NEWinogradConvolutionLayer>, pd_t, data_t>(
+            ctx, acl_wino_obj, pd());
+}
+
+} // namespace acl
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/acl/acl_winograd_convolution.hpp
+++ b/src/cpu/acl/acl_winograd_convolution.hpp
@@ -1,0 +1,149 @@
+/*******************************************************************************
+* Copyright 2020-2022 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_ACL_WINOGRAD_CONVOLUTION_HPP
+#define CPU_AARCH64_ACL_WINOGRAD_CONVOLUTION_HPP
+
+#include "cpu/cpu_convolution_pd.hpp"
+
+#include "cpu/acl/acl_convolution_utils.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace acl {
+
+struct acl_wino_resource_t : public resource_t {
+    acl_wino_resource_t()
+        : acl_wino_obj_(utils::make_unique<
+                acl_obj_t<arm_compute::NEWinogradConvolutionLayer>>()) {}
+
+    status_t configure(const acl_conv_conf_t &acp) {
+        if (!acl_wino_obj_) return status::out_of_memory;
+
+        // Init Compute Library tensors based on info from descriptor
+        acl_wino_obj_->src_tensor.allocator()->init(acp.src_tensor_info);
+        acl_wino_obj_->wei_tensor.allocator()->init(acp.wei_tensor_info);
+        acl_wino_obj_->dst_tensor.allocator()->init(acp.dst_tensor_info);
+        acl_wino_obj_->bia_tensor.allocator()->init(acp.bia_tensor_info);
+
+        // clang-format off
+        acl_wino_obj_->conv.configure(
+            &acl_wino_obj_->src_tensor,
+            &acl_wino_obj_->wei_tensor,
+            acp.with_bias ? &acl_wino_obj_->bia_tensor : nullptr,
+            &acl_wino_obj_->dst_tensor,
+            acp.padstride_info,
+            acp.act_info,
+            true); // to support 5x5, 7x7 filter shapes in addition to 3x3
+        // clang-format on
+
+        return status::success;
+    }
+
+    acl_obj_t<arm_compute::NEWinogradConvolutionLayer> &get_acl_obj() const {
+        return *acl_wino_obj_;
+    }
+
+    DNNL_DISALLOW_COPY_AND_ASSIGN(acl_wino_resource_t);
+
+private:
+    std::unique_ptr<acl_obj_t<arm_compute::NEWinogradConvolutionLayer>>
+            acl_wino_obj_;
+}; // acl_wino_resource_t
+
+struct acl_wino_convolution_fwd_t : public primitive_t {
+    struct pd_t : public cpu_convolution_fwd_pd_t {
+        pd_t(const convolution_desc_t *adesc, const primitive_attr_t *attr,
+                const typename pd_t::base_class *hint_fwd_pd)
+            : cpu_convolution_fwd_pd_t(adesc, attr, hint_fwd_pd)
+            , acp_()
+            , post_ops() {}
+
+        DECLARE_COMMON_PD_T(
+                "wino:acl", acl_wino_convolution_fwd_t, USE_GLOBAL_SCRATCHPAD);
+
+        status_t init(engine_t *engine) {
+            using namespace data_type;
+            const bool is_fp16_ok = expect_data_types(f16, f16, f16, f16, undef)
+                    && attr()->has_default_values(
+                            primitive_attr_t::skip_mask_t::post_ops, f16);
+            const bool is_fp32_ok = expect_data_types(f32, f32, f32, f32, undef)
+                    && attr()->has_default_values(
+                            primitive_attr_t::skip_mask_t::post_ops, f32);
+            bool ok = is_fwd()
+                    && utils::one_of(desc()->alg_kind,
+                            alg_kind::convolution_auto,
+                            alg_kind::convolution_winograd)
+                    && utils::one_of(true, is_fp16_ok, is_fp32_ok)
+                    && !has_zero_dim_memory();
+            if (!ok) return status::unimplemented;
+
+            CHECK(acl_convolution_utils::init_conf_wino(acp_, src_md_,
+                    weights_md_, dst_md_, bias_md_, *desc(), *attr()));
+
+            set_default_alg_kind(alg_kind::convolution_winograd);
+
+            CHECK(post_ops.init(
+                    engine, attr_.post_ops_, dst_md_, acp_.act_info));
+            acp_.use_dst_acc = post_ops.has_sum();
+
+            return status::success;
+        }
+
+        acl_conv_conf_t acp_;
+        acl_post_ops_t post_ops;
+    };
+
+    acl_wino_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
+
+    status_t create_resource(
+            engine_t *engine, resource_mapper_t &mapper) const override {
+        if (mapper.has_resource(this)) return status::success;
+
+        auto r = utils::make_unique<acl_wino_resource_t>();
+        if (!r) return status::out_of_memory;
+
+        // Configure the resource based on information from primitive descriptor
+        CHECK(r->configure(pd()->acp_));
+        mapper.add(this, std::move(r));
+
+        CHECK(pd()->post_ops.create_resource(engine, mapper));
+
+        return status::success;
+    }
+
+    ~acl_wino_convolution_fwd_t() {}
+
+    typedef typename prec_traits<data_type::f32>::type data_t;
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        return execute_forward(ctx);
+    }
+
+private:
+    // To guard the const execute_forward(), the mutex must be 'mutable'
+    mutable std::mutex mtx;
+    status_t execute_forward(const exec_ctx_t &ctx) const;
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+}; // acl_wino_convolution_fwd_t
+
+} // namespace acl
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_AARCH64_ACL_WINOGRAD_CONVOLUTION_HPP

--- a/src/cpu/acl/matmul/acl_matmul.hpp
+++ b/src/cpu/acl/matmul/acl_matmul.hpp
@@ -32,14 +32,19 @@ struct acl_resource_t : public resource_t {
 
     status_t configure(const acl_matmul_conf_t &amp) {
         if (!acl_obj_) return status::out_of_memory;
-        acl_obj_->src_tensor.allocator()->init(amp.src_tensor_info);
-        acl_obj_->wei_tensor.allocator()->init(amp.wei_tensor_info);
-        acl_obj_->dst_tensor.allocator()->init(amp.dst_tensor_info);
+        acl_obj_->src_tensor.allocator()->init(amp.src_info);
+        acl_obj_->wei_tensor.allocator()->init(amp.wei_info);
+        acl_obj_->dst_tensor.allocator()->init(amp.dst_info);
         // Configure transpose kernel for src, wei or both
         if (amp.is_transA) {
             acl_obj_->src_acc_tensor.allocator()->init(amp.src_acc_info);
             acl_obj_->transA.configure(
                     &acl_obj_->src_acc_tensor, &acl_obj_->src_tensor);
+        }
+        if (amp.is_transB) {
+            acl_obj_->wei_acc_tensor.allocator()->init(amp.wei_acc_info);
+            acl_obj_->transB.configure(
+                    &acl_obj_->wei_acc_tensor, &acl_obj_->wei_tensor);
         }
         // Configure GEMM
         acl_obj_->gemm.configure(&acl_obj_->src_tensor, &acl_obj_->wei_tensor,
@@ -78,9 +83,7 @@ struct acl_matmul_t : public primitive_t {
                     && platform::has_data_type_support(data_type::f16);
             bool ok = is_dense_data()
                     && utils::one_of(true, is_fp32_ok, is_fp16_ok)
-                    && !has_zero_dim_memory()
-                    && weights_md_.format_kind == format_kind::any
-                    && set_default_formats()
+                    && !has_zero_dim_memory() && set_default_formats()
                     && attr()->has_default_values(
                             smask_t::oscale | smask_t::post_ops)
                     && attr_oscale_ok() && !has_runtime_dims_or_strides();
@@ -95,9 +98,9 @@ struct acl_matmul_t : public primitive_t {
             amp_.use_dst_acc = post_ops.has_sum();
 
             // Validate ACL GEMM
-            ACL_CHECK_VALID(arm_compute::NEGEMM::validate(&amp_.src_tensor_info,
-                    &amp_.wei_tensor_info, nullptr, &amp_.dst_tensor_info,
-                    amp_.alpha, 0.0f, amp_.gemm_info));
+            ACL_CHECK_VALID(arm_compute::NEGEMM::validate(&amp_.src_info,
+                    &amp_.wei_info, nullptr, &amp_.dst_info, amp_.alpha, 0.0f,
+                    amp_.gemm_info));
 
             return status::success;
         }

--- a/src/cpu/acl/matmul/acl_matmul_utils.cpp
+++ b/src/cpu/acl/matmul/acl_matmul_utils.cpp
@@ -41,7 +41,6 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
     const dim_t src_batch = helper.src_batch();
     const dim_t wei_batch = helper.wei_batch();
 
-    // We can only broadcast on one of src or wei at once
     // ACL supports broadcast for 3D shapes, and 4D shapes
     // for e.g when ab in abcd is 1x1
     bool batch_ok = IMPLICATION(src_batch > 1, wei_batch == 1)
@@ -54,18 +53,19 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
     bool with_bias = md.bias_desc.format_kind != format_kind::undef;
     ACL_CHECK_SUPPORT(with_bias, "ACL does not support bias for matmul");
 
-    // The two innermost dimensions can be transposed, but the batch dimensions
-    // must be the outermost
     using namespace format_tag;
     auto src_tag = memory_desc_matches_one_of_tag(
             src_md, abcd, abdc, abc, acb, ab, ba);
+    auto wei_tag = memory_desc_matches_one_of_tag(
+            wei_md, abcd, abdc, abc, acb, ab, ba);
     auto dst_tag = memory_desc_matches_one_of_tag(dst_md, abcd, abc, ab, ba);
-    ACL_CHECK_SUPPORT(utils::one_of(format_tag::undef, src_tag, dst_tag),
+    ACL_CHECK_SUPPORT(
+            utils::one_of(format_tag::undef, src_tag, wei_tag, dst_tag),
             "Format tag is undefined");
 
-    // Transpose A (src)
+    // Transpose A (src) or B (wei)
     amp.is_transA = helper.transA() == 'T';
-
+    amp.is_transB = helper.transB() == 'T';
     auto acl_src_data_t = acl_utils::get_acl_data_t(src_md.data_type);
     auto acl_wei_data_t = acl_utils::get_acl_data_t(wei_md.data_type);
     auto acl_dst_data_t = acl_utils::get_acl_data_t(dst_md.data_type);
@@ -74,13 +74,20 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
         amp.src_acc_info = arm_compute::TensorInfo(
                 arm_compute::TensorShape(M, K, 1, src_batch), 1,
                 acl_src_data_t);
+    if (amp.is_transB)
+        amp.wei_acc_info = arm_compute::TensorInfo(
+                arm_compute::TensorShape(K, N, wei_batch), 1, acl_wei_data_t);
 
-    amp.src_tensor_info = arm_compute::TensorInfo(
+    amp.src_info = arm_compute::TensorInfo(
             arm_compute::TensorShape(K, M, 1, src_batch), 1, acl_src_data_t);
-    amp.wei_tensor_info = arm_compute::TensorInfo(
+    amp.wei_info = arm_compute::TensorInfo(
             arm_compute::TensorShape(N, K, wei_batch), 1, acl_wei_data_t);
-    amp.dst_tensor_info = arm_compute::TensorInfo(
+    amp.dst_info = arm_compute::TensorInfo(
             arm_compute::TensorShape(N, M, 1, dst_batch), 1, acl_dst_data_t);
+
+    bool is_fastmath_enabled = utils::one_of(
+            attr.fpmath_mode_, fpmath_mode::bf16, fpmath_mode::any);
+    amp.gemm_info.set_fast_math(is_fastmath_enabled);
 
     // Set alpha (output scaling)
     // TODO: Add runtime scales support. Creation time scales will be remove
@@ -91,45 +98,10 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
     // Validate ACL transpose
     if (amp.is_transA)
         ACL_CHECK_VALID(arm_compute::NETranspose::validate(
-                &amp.src_acc_info, &amp.src_tensor_info));
-
-    bool is_fastmath_enabled = utils::one_of(
-            attr.fpmath_mode_, fpmath_mode::bf16, fpmath_mode::any);
-    amp.gemm_info.set_fast_math(is_fastmath_enabled);
-
-    amp.gemm_info.set_fixed_format(true);
-
-    // WeightFormat::ANY tells ACL we can handle any format
-    amp.gemm_info.set_weight_format(arm_compute::WeightFormat::ANY);
-
-    // Get the format that the ACL kernel will expect the weights to be
-    // in (if a kernel exists). Note that these are referred to as fixed format
-    // kernels, because they require one specific weights format
-    arm_compute::WeightFormat expected_weight_format;
-    ACL_CHECK_VALID(arm_compute::NEGEMM::has_opt_impl(expected_weight_format,
-            &amp.src_tensor_info, &amp.wei_tensor_info, nullptr,
-            &amp.dst_tensor_info, amp.alpha, 0.0f, amp.gemm_info));
-
-    // Set gemm weights info to the one returned by has_opt_impl
-    amp.gemm_info.set_weight_format(expected_weight_format);
-
-    // has_opt_impl may return a non fast math kernel, even if we requested one
-    amp.gemm_info.set_fast_math(
-            arm_compute::is_fixed_format_fast_math(expected_weight_format));
-
-    // Logical dimension indices
-    dim_t innermost_dim = wei_md.ndims - 1;
-    dim_t N_dim = innermost_dim;
-    dim_t K_dim = innermost_dim - 1;
-
-    // The logical indices of dimensions related to the batch, ordered from
-    // innermost to outermost
-    std::vector<dim_t> batch_dims = {};
-    for (dim_t i = K_dim - 1; i >= 0; --i)
-        batch_dims.push_back(i);
-
-    acl_utils::reorder_to_weight_format(amp.wei_tensor_info, wei_md,
-            expected_weight_format, K_dim, N_dim, {}, batch_dims);
+                &amp.src_acc_info, &amp.src_info));
+    if (amp.is_transB)
+        ACL_CHECK_VALID(arm_compute::NETranspose::validate(
+                &amp.wei_acc_info, &amp.wei_info));
 
     return status::success;
 }

--- a/src/cpu/acl/matmul/acl_matmul_utils.hpp
+++ b/src/cpu/acl/matmul/acl_matmul_utils.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2021-2023 Arm Ltd. and affiliates
+* Copyright 2021-2022 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -14,8 +14,8 @@
 * limitations under the License.
 *******************************************************************************/
 
-#ifndef CPU_ACL_MATMUL_UTILS_HPP
-#define CPU_ACL_MATMUL_UTILS_HPP
+#ifndef CPU_AARCH64_ACL_MATMUL_UTILS_HPP
+#define CPU_AARCH64_ACL_MATMUL_UTILS_HPP
 
 #include "cpu/matmul/cpu_matmul_pd.hpp"
 
@@ -29,21 +29,25 @@ namespace acl {
 struct acl_matmul_obj_t {
     arm_compute::NEGEMM gemm;
     arm_compute::NETranspose transA;
+    arm_compute::NETranspose transB;
     arm_compute::Tensor src_tensor;
     arm_compute::Tensor src_acc_tensor;
     arm_compute::Tensor wei_tensor;
+    arm_compute::Tensor wei_acc_tensor;
     arm_compute::Tensor dst_tensor;
 };
 
 struct acl_matmul_conf_t {
     bool is_transA;
+    bool is_transB;
     // If this is true, the result of the matmul goes into a temporarily
     // allocated ACL tensor to be accumulated into the oneDNN dst during postops
     bool use_dst_acc;
-    arm_compute::TensorInfo src_tensor_info;
+    arm_compute::TensorInfo src_info;
     arm_compute::TensorInfo src_acc_info;
-    arm_compute::TensorInfo wei_tensor_info;
-    arm_compute::TensorInfo dst_tensor_info;
+    arm_compute::TensorInfo wei_info;
+    arm_compute::TensorInfo wei_acc_info;
+    arm_compute::TensorInfo dst_info;
     arm_compute::GEMMInfo gemm_info;
     float alpha;
 };
@@ -61,4 +65,4 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
 } // namespace impl
 } // namespace dnnl
 
-#endif // CPU_ACL_MATMUL_UTILS_HPP
+#endif // CPU_AARCH64_ACL_MATMUL_UTILS_HPP

--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -70,6 +70,7 @@ using namespace dnnl::impl::cpu::aarch64;
 #include "cpu/acl/acl_gemm_convolution.hpp"
 #include "cpu/acl/acl_indirect_gemm_convolution.hpp"
 #include "cpu/acl/acl_depthwise_convolution.hpp"
+#include "cpu/acl/acl_winograd_convolution.hpp"
 using namespace dnnl::impl::cpu::acl;
 #endif
 
@@ -112,6 +113,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_SSE41(jit_sse41_1x1_convolution_fwd_t)
             CPU_INSTANCE_AVX2(jit_avx2_convolution_fwd_t)
             CPU_INSTANCE_SSE41(jit_sse41_convolution_fwd_t)
+            CPU_INSTANCE_ACL(acl_wino_convolution_fwd_t)
             CPU_INSTANCE_ACL(acl_dw_convolution_fwd_t, f32)
             CPU_INSTANCE_AARCH64(jit_sve_512_dw_convolution_fwd_t)
             CPU_INSTANCE_AARCH64(jit_sve_512_1x1_convolution_fwd_f32_t)
@@ -196,6 +198,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AVX2(brgemm_1x1_convolution_fwd_t, avx2_vnni_2)
             CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t, avx2_vnni_2)
             CPU_INSTANCE_AVX2(brgemm_convolution_fwd_t, avx2_vnni_2, true)
+            CPU_INSTANCE_ACL(acl_wino_convolution_fwd_t)
             CPU_INSTANCE_ACL(acl_indirect_gemm_convolution_fwd_t)
             CPU_INSTANCE_ACL(acl_gemm_convolution_fwd_t, f16)
             CPU_INSTANCE(ref_convolution_fwd_t)


### PR DESCRIPTION
v3_2 acl matmul requires 'any' format for weights to use
has_opt_impl() feature.
Adaptation in CPU plugin is required and performance is not
guaranteed.

OV pr:
- https://github.com/openvinotoolkit/openvino/pull/18589