### PR TITLE
[FORK] [FIX] Fix legacy zero point issue on AVX2 + AVX512.

### DIFF
--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -572,7 +572,12 @@ std::ostream &operator<<(std::ostream &ss, const primitive_attr_t *attr) {
         }
         ss << " ";
     }
-
+    const auto &legacy_input_zp = attr->input_zero_points_;
+    if (!legacy_input_zp.has_default_values()) {
+        ss << "attr-legacy-input-zero-points:";
+        ss << ":" << get_val_str(legacy_input_zp.mask_) << ":" << get_val_str(legacy_input_zp.count_);
+        ss << " ";
+    }
     const post_ops_t &po = attr->post_ops_;
     if (!po.has_default_values()) {
         std::string delim = empty_delim;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -679,7 +679,7 @@ void _jit_avx512_core_x8s8s32x_1x1_conv_kernel<Vmm>::generate() {
                 reg_src_zero_point);
     }
     if (jcp.dst_scale) {
-        if (!jcp.signed_input)
+        if (!jcp.signed_input && !jcp.with_input_zp)
             mov(EVEX_compress_addr(rsp, reg_bias_data_off), reg_bias_data);
         mov(reg_ptr_dst_scale, ptr[param1 + GET_OFF(dst_scale)]);
         mov(EVEX_compress_addr(rsp, reg_dst_scale_off), reg_ptr_dst_scale);

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
@@ -551,7 +551,7 @@ void _jit_uni_x8s8s32x_1x1_conv_kernel<isa, Vmm>::generate() {
         mov(ptr[rsp + reg_src_zero_point_off], reg_src_zero_point);
     }
     if (jcp.dst_scale) {
-        if (!jcp.signed_input) mov(ptr[rsp + reg_bias_data_off], reg_bias_data);
+        if (!jcp.signed_input && !jcp.with_input_zp) mov(ptr[rsp + reg_bias_data_off], reg_bias_data);
         mov(reg_ptr_dst_scale, ptr[param1 + GET_OFF(dst_scale)]);
         mov(ptr[rsp + reg_dst_scale_off], reg_ptr_dst_scale);
     }


### PR DESCRIPTION
[FEATURE]Migrate legacy post ops and zero points on runtime data pointers
### Details:
 - The issue should has been introduced when migrating to ONEDNN 3.1.  Fork legacy input zero point compensation need to update registers conflict handling code flow as signed_input mechanism. 

    const Xbyak::Reg64 reg_bias_data = r12;
    const Xbyak::Reg64 reg_comp_data = r12;
    const Xbyak::Reg64 reg_ptr_dst_scale = r12;

### Tickets:
 - *CVS-114070*