### PR TITLE
[FEATURE][ARM] Add fp16<->fp16 direct copy reorder instance

### DIFF
--- a/src/cpu/reorder/cpu_reorder.hpp
+++ b/src/cpu/reorder/cpu_reorder.hpp
@@ -140,6 +140,12 @@ using aarch64_jit_uni_reorder_t = aarch64::jit_uni_reorder_t;
 #define REG_FAST_DIRECT_COPY_F32_F32
 #endif
 
+#if defined(DNNL_AARCH64) || defined(DNNL_ARM)
+#define REG_FAST_DIRECT_COPY_F16_F16 REG_SR_DIRECT_COPY(f16, f16)
+#else
+#define REG_FAST_DIRECT_COPY_F16_F16
+#endif
+
 #ifdef __INTEL_COMPILER
 /* direct copy for icc, which is faster than jitted code */
 #define REG_FAST_DIRECT_COPY(sdt, ddt) REG_SR_DIRECT_COPY(sdt, ddt)

--- a/src/cpu/reorder/cpu_reorder_regular_f16.cpp
+++ b/src/cpu/reorder/cpu_reorder_regular_f16.cpp
@@ -26,6 +26,7 @@ const impl_list_map_t &regular_f16_impl_list_map() {
     static const impl_list_map_t the_map = REG_REORDER_P({
         // f16 ->
         {{f16, data_type::undef, 0}, {
+            REG_FAST_DIRECT_COPY_F16_F16
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::brgemm_matmul_matrix_B_reorder_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64_jit_blk_reorder_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64_jit_uni_reorder_t))


### PR DESCRIPTION
-  ARM implementation of jit_reorder lacks fp16 support, so direct copy instance provides better performance
