### PR TITLE
[CC] fix failure of create primitive_desc

### DIFF
--- a/src/common/primitive_desc.hpp
+++ b/src/common/primitive_desc.hpp
@@ -410,6 +410,7 @@ protected:
         CHECK(_pd->init(engine));
         CHECK(_pd->init_scratchpad_md());
         *pd = _pd.release();
+        DNNL_PRIMITIVE_CREATE(pd_t);
         return success;
     }
 


### PR DESCRIPTION
# Description

Fix issue of failure during creating primitive desc in case of conditional compilation:
oneDNN requires forward pd to exists until primitive is created, so such primitives need to be kept to create its primitive_desc.

Failure case: Deconvolution::createDescriptor will call createDescriptorInternalDefault() to create fwd_conv_pd, sometimes ref_convolution_fwd_t will be chosen to return its primitive_desc, but ref_convolution_fwd_t primitive will not be created finally, then CC will not put this primitive into convolution_impl_list in selective build stage, the final CC package will fail due to cannot create fwd_conv_pd of ref_convolution_fwd_t.

Fixes # (github issue)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
