### PR TITLE
[FORK][FIX] Fixed -Wdeprecated-enum-enum-conversion error

### DIFF
--- a/src/cpu/x64/jit_uni_fork_dw_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_uni_fork_dw_conv_kernel_f32.cpp
@@ -817,7 +817,7 @@ void jit_uni_fork_dw_conv_fwd_kernel_f32<isa>::generate() {
     Label exit_label;
 
     int ch_blocks_tail = jcp.nb_ch % jcp.nb_ch_blocking;
-    if (isa & avx512_core_bit) {
+    if (static_cast<unsigned>(isa) & avx512_core_bit) {
         const auto oc_tail = jcp.oc_without_padding % jcp.ch_block;
         if (oc_tail != 0) {
             // Prepare masks for tailing


### PR DESCRIPTION
# Description

Please include a summary of the change. Please also include relevant motivation and context. See [contribution guidelines](https://github.com/oneapi-src/oneDNN/blob/master/CONTRIBUTING.md) for more details. If the change fixes an issue not documented in the project's Github issue tracker, please document all steps necessary to reproduce it.

Fixes # (github issue)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
