### PR TITLE
support (src_f32,wei_fp16,dst_f32) in ip

### DIFF
--- a/src/cpu/cpu_inner_product_list.cpp
+++ b/src/cpu/cpu_inner_product_list.cpp
@@ -76,6 +76,11 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t, avx2)
             nullptr,
         }},
+        {{forward, f32, f16, f32}, {
+            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t, avx512_core)
+            CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t, avx2)
+            nullptr,
+        }},
         {{forward, bf16, bf16, f32}, {
             CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t, avx512_core_amx)
             CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t, avx512_core_bf16)

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -2141,8 +2141,11 @@ void jit_brgemm_kernel_t<isa, Wmm>::gemm_microkernel(int bd_block2,
                             vcvtneeph2ps(vmm_load, addr);
                         else
                             vcvtneoph2ps(vmm_load, addr);
-                    } else
+                    } else if (brg.isa_impl == avx512_core_fp16) {
                         vcvtph2psx(vmm_load, addr);
+                    } else {
+                        vcvtph2ps(vmm_load, addr);
+                    }
                 } else if (brg.dt_b == data_type::bf16
                         && brg.isa_impl == avx2_vnni_2) {
                     if (rd % 2 == 0)
@@ -2418,8 +2421,10 @@ void jit_brgemm_kernel_t<isa, Wmm>::gemm_microkernel(int bd_block2,
                             vcvtneeph2ps(vmm_load, addr);
                         else
                             vcvtneoph2ps(vmm_load, addr);
-                    } else {
+                    }  if (brg.isa_impl == avx512_core_fp16) {
                         vcvtph2psx(vmm_load, addr);
+                    } else {
+                        vcvtph2ps(vmm_load, addr);
                     }
                 } else if (brg.dt_b == data_type::bf16
                         && brg.isa_impl == avx2_vnni_2) {

--- a/src/cpu/x64/jit_brgemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_inner_product_utils.cpp
@@ -153,7 +153,8 @@ jit_brgemm_ip_conf_t::get_desired_weights_tag() const {
     const bool is_xf16 = utils::one_of(jbgp.wei_dt, bf16, f16);
     const bool is_not_vnni_tag = (jbgp.wei_dt == f32
             || (jbgp.wei_dt == f16 && jbgp.isa == avx512_core_fp16)) && !jbgp.weights_decompression;
-    if (is_not_vnni_tag || (jbgp.weights_decompression && jbgp.orig_wei_dt == u8 && !jbgp.with_src_dynamic_quant)) {
+    const bool is_vcvtph2ps_kernel = (jbgp.orig_wei_dt == f16 && jbgp.src_dt == f32);
+    if (is_not_vnni_tag || (jbgp.weights_decompression && (jbgp.orig_wei_dt == u8 || is_vcvtph2ps_kernel) && !jbgp.with_src_dynamic_quant)) {
         if (is_superset(jbgp.isa, avx512_core))
             return {{64,
                             pick(n_sp_dims, OI16i64o, OIw16i64o, OIhw16i64o,
@@ -1393,7 +1394,7 @@ status_t jit_brgemm_ip_conf_t::init_conf_base(cpu_isa_t isa,
     jbgp.wei_dt = weights_d.data_type();
 
     jbgp.weights_decompression = one_of(jbgp.src_dt, f32, bf16) &&
-                                 one_of(jbgp.wei_dt, u8, nf4, s4, u4);
+                                 one_of(jbgp.wei_dt, u8, nf4, s4, u4, f16);
     jbgp.wei_decomp_algo = weights_decomp_kind_t::immediate;
     jbgp.orig_wei_dt = jbgp.wei_dt;
     jbgp.with_grouped_weights_decompression = false;

--- a/src/cpu/x64/jit_brgemm_weights_decompression_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_weights_decompression_kernel.cpp
@@ -123,6 +123,10 @@ void jit_brgemm_weights_decompression_kernel_t<isa>::load_weights(Vmm vmm_load, 
             }
             break;
         }
+        case data_type::f16: {
+            vcvtph2ps(vmm_load, addr);
+            break;
+        }
         default: assert(!"unsupported data type");
     }
 }


### PR DESCRIPTION
# Description

Add support for (src_f32, weight_f16, dst_f32) in inner product

Fixes CVS-133453

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
