### PR TITLE
Support weight-compressed date type s8

### DIFF
--- a/include/oneapi/dnnl/dnnl.h
+++ b/include/oneapi/dnnl/dnnl.h
@@ -2404,7 +2404,8 @@ dnnl_status_t DNNL_API dnnl_primitive_attr_get_rnn_weights_projection_qparams(
 
 dnnl_status_t DNNL_API dnnl_primitive_attr_set_src_dyn_quant_params(
         dnnl_primitive_attr_t attr, uint64_t group_size);
-
+dnnl_status_t DNNL_API  dnnl_primitive_attr_get_src_dyn_quant_params(
+        dnnl_primitive_attr_t attr, uint64_t* group_size);
 /// @} dnnl_api_attributes
 
 /// @addtogroup dnnl_api_rnn

--- a/include/oneapi/dnnl/dnnl.hpp
+++ b/include/oneapi/dnnl/dnnl.hpp
@@ -4176,6 +4176,11 @@ struct primitive_attr : public handle<dnnl_primitive_attr_t> {
         error::wrap_c_api(dnnl_primitive_attr_set_src_dyn_quant_params(get(), group_size),
                 "could not set src dynamic quantization parameters primitive attribute");
     }
+
+    void get_src_dyn_quant_params(uint64_t& group_size) const {
+        error::wrap_c_api(dnnl_primitive_attr_get_src_dyn_quant_params(get(), &group_size),
+                "could not get src dynamic quantization parameters primitive attribute");
+    }
 };
 
 /// @} dnnl_api_attributes

--- a/src/common/inner_product.cpp
+++ b/src/common/inner_product.cpp
@@ -126,7 +126,7 @@ status_t ip_attr_check(const inner_product_desc_t &desc, const engine_t *engine,
                     || utils::one_of(dst_dt, data_type::s8, data_type::u8,
                             data_type::s32);
         if (engine->kind() == engine_kind::cpu)
-            is_int8 |= one_of(wei_dt, data_type::u8, data_type::nf4, data_type::s4, data_type::u4);
+            is_int8 |= one_of(wei_dt, data_type::u8, data_type::s8, data_type::nf4, data_type::s4, data_type::u4);
         if (is_int8) fwd_attr_mask |= smask_t::scales_runtime | smask_t::zero_points_runtime | smask_t::src_dyn_quant_params;
 
         VCHECK_IP_UNIMPL(attr->has_default_values(fwd_attr_mask, dst_dt),

--- a/src/common/primitive_attr.cpp
+++ b/src/common/primitive_attr.cpp
@@ -899,6 +899,14 @@ status_t dnnl_primitive_attr_set_src_dyn_quant_params(
     return attr->src_dyn_quant_params_.set(group_size);
 }
 
+status_t dnnl_primitive_attr_get_src_dyn_quant_params(
+        primitive_attr_t *attr, uint64_t* group_size) {
+    if (attr == nullptr) return invalid_arguments;
+
+    if (group_size) *group_size = attr->src_dyn_quant_params_.get();
+    return success;
+}
+
 template struct dnnl::impl::shifts_t<uint8_t>;
 template struct dnnl::impl::shifts_t<int32_t>;
 template struct dnnl::impl::shifts_t<float>;

--- a/src/common/primitive_attr.hpp
+++ b/src/common/primitive_attr.hpp
@@ -497,6 +497,10 @@ struct src_dyn_quant_params_t : public c_compatible {
         return status::success;
     }
 
+    uint64_t get() {
+        return group_size_;
+    }
+
     bool operator==(const src_dyn_quant_params_t &rhs) const {
         using namespace utils;
         return group_size_ == rhs.group_size_;

--- a/src/common/type_helpers.hpp
+++ b/src/common/type_helpers.hpp
@@ -287,7 +287,7 @@ inline data_type_t default_accum_data_type(data_type_t src_dt,
 
     /* prop_kind doesn't matter */
     if (everyone_is(f32, src_dt, wei_dt)) return f32;
-    if (one_of(src_dt, f32, bf16) && one_of(wei_dt, u8, nf4, s4, u4)) return f32;
+    if (one_of(src_dt, f32, bf16) && one_of(wei_dt, u8, s8, nf4, s4, u4)) return f32;
     if (everyone_is(f64, src_dt, wei_dt)) return f64;
 
     if (one_of(prop_kind, forward_training, forward_inference)) {

--- a/src/cpu/cpu_inner_product_list.cpp
+++ b/src/cpu/cpu_inner_product_list.cpp
@@ -59,6 +59,13 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t, avx2)
             nullptr,
         }},
+        {{forward, f32, s8, f32}, {
+            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t, avx512_core_vnni)
+            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t, avx512_core)
+            CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t, avx2_vnni)
+            CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t, avx2)
+            nullptr,
+        }},
         {{forward, f32, nf4, f32}, {
             CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t, avx512_core)
             CPU_INSTANCE_AVX2(brgemm_inner_product_fwd_t, avx2)
@@ -103,6 +110,16 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             nullptr,
         }},
         {{forward, bf16, u8, bf16}, {
+            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t, avx512_core_amx)
+            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t, avx512_core_bf16)
+            nullptr,
+        }},
+        {{forward, bf16, s8, f32}, {
+            CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t, avx512_core_amx)
+            CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t, avx512_core_bf16)
+            nullptr,
+        }},        
+        {{forward, bf16, s8, bf16}, {
             CPU_INSTANCE_AMX(brgemm_inner_product_fwd_t, avx512_core_amx)
             CPU_INSTANCE_AVX512(brgemm_inner_product_fwd_t, avx512_core_bf16)
             nullptr,

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -52,9 +52,9 @@ void init_kernel_datatype(
     brg->is_int8 = utils::one_of(dt_a, data_type::u8, data_type::s8)
             && utils::one_of(dt_b, data_type::u8, data_type::s8, data_type::u4);
     brg->is_bf16 = one_of(dt_a, data_type::bf16) &&
-                   one_of(dt_b, data_type::bf16, data_type::u8, data_type::nf4, data_type::s4, data_type::u4);
+                   one_of(dt_b, data_type::bf16, data_type::u8, data_type::s8, data_type::nf4, data_type::s4, data_type::u4);
     brg->is_f32 = one_of(dt_a, data_type::f32) &&
-                  one_of(dt_b, data_type::f32, data_type::u8, data_type::nf4, data_type::s4, data_type::u4);
+                  one_of(dt_b, data_type::f32, data_type::u8, data_type::s8, data_type::nf4, data_type::s4, data_type::u4);
     brg->is_f16 = utils::one_of(data_type::f16, dt_a, dt_b);
     assert(brg->is_int8 || brg->is_bf16 || brg->is_f32 || brg->is_f16);
 }
@@ -864,7 +864,7 @@ void init_brgemm_conf(brgemm_t *brg, cpu_isa_t isa, brgemm_batch_kind_t type,
 
     const bool is_vcvtph2ps_kernel = (brg->dt_b == data_type::f16 && brg->dt_a == data_type::f32);
     const bool is_b_in_vnni_format = !(brg->dt_b == data_type::f16 && brg->isa_impl == avx512_core_fp16) &&
-                                     !(one_of(brg->dt_a, data_type::f32, data_type::bf16) && one_of(brg->dt_b, data_type::u8)) &&
+                                     !(one_of(brg->dt_a, data_type::f32, data_type::bf16) && one_of(brg->dt_b, data_type::u8, data_type::s8)) &&
                                      !is_vcvtph2ps_kernel;
     brg->ld_step
             = is_b_in_vnni_format ? data_type_vnni_granularity(brg->dt_b) : 1;
@@ -874,7 +874,7 @@ void init_brgemm_conf(brgemm_t *brg, cpu_isa_t isa, brgemm_batch_kind_t type,
                       && one_of(brg->isa_impl, avx2_vnni_2, avx512_core_fp16))
             || (brg->is_bf16 && brg->isa_impl == avx2_vnni_2)
             || (one_of(brg->dt_a, data_type::f32, data_type::bf16) &&
-                one_of(brg->dt_b, data_type::u8, data_type::nf4, data_type::s4, data_type::u4, data_type::f16));
+                one_of(brg->dt_b, data_type::u8, data_type::s8, data_type::nf4, data_type::s4, data_type::u4, data_type::f16));
     brg->rd_step = has_no_vnni_compute_instruction
             ? 1
             : data_type_vnni_granularity(brg->dt_b);

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -2289,6 +2289,9 @@ void jit_brgemm_kernel_t<isa, Wmm>::gemm_microkernel(int bd_block2,
                     if (brg.dt_b == data_type::u8) {
                         uni_vpmovzxbd(vmm_load, addr);
                         uni_vcvtdq2ps(vmm_load, vmm_load);
+                    } else if (brg.dt_b == data_type::s8) {
+                        uni_vpmovsxbd(vmm_load, addr);
+                        uni_vcvtdq2ps(vmm_load, vmm_load);
                     } else if (brg.dt_b == data_type::u4) {
                         uni_vpmovzxbd(vmm_load, addr);
                         if (rd % 2 == 0) {

--- a/src/cpu/x64/jit_brgemm_inner_product.hpp
+++ b/src/cpu/x64/jit_brgemm_inner_product.hpp
@@ -62,7 +62,7 @@ struct brgemm_inner_product_fwd_t : public primitive_t {
             auto wei_dt = invariant_wei_md()->data_type;
             const bool is_int8 = one_of(src_dt, u8, s8);
             const bool is_wei_decomp = one_of(src_dt, f32, bf16) &&
-                                       one_of(wei_dt, u8, nf4, s4, u4, f16);
+                                       one_of(wei_dt, u8, s8, nf4, s4, u4, f16);
 
             using skip_mask_t = primitive_attr_t::skip_mask_t;
             auto skip_mask = skip_mask_t::post_ops | skip_mask_t::sum_dt;

--- a/src/cpu/x64/jit_brgemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_inner_product_utils.cpp
@@ -154,7 +154,7 @@ jit_brgemm_ip_conf_t::get_desired_weights_tag() const {
     const bool is_not_vnni_tag = (jbgp.wei_dt == f32
             || (jbgp.wei_dt == f16 && jbgp.isa == avx512_core_fp16)) && !jbgp.weights_decompression;
     const bool is_vcvtph2ps_kernel = (jbgp.orig_wei_dt == f16 && jbgp.src_dt == f32);
-    if (is_not_vnni_tag || (jbgp.weights_decompression && (jbgp.orig_wei_dt == u8 || is_vcvtph2ps_kernel) && !jbgp.with_src_dynamic_quant)) {
+    if (is_not_vnni_tag || (jbgp.weights_decompression && (jbgp.orig_wei_dt == u8 || jbgp.orig_wei_dt == s8 || is_vcvtph2ps_kernel) && !jbgp.with_src_dynamic_quant)) {
         if (is_superset(jbgp.isa, avx512_core))
             return {{64,
                             pick(n_sp_dims, OI16i64o, OIw16i64o, OIhw16i64o,
@@ -1394,7 +1394,7 @@ status_t jit_brgemm_ip_conf_t::init_conf_base(cpu_isa_t isa,
     jbgp.wei_dt = weights_d.data_type();
 
     jbgp.weights_decompression = one_of(jbgp.src_dt, f32, bf16) &&
-                                 one_of(jbgp.wei_dt, u8, nf4, s4, u4, f16);
+                                 one_of(jbgp.wei_dt, u8, s8, nf4, s4, u4, f16);
     jbgp.wei_decomp_algo = weights_decomp_kind_t::immediate;
     jbgp.orig_wei_dt = jbgp.wei_dt;
     jbgp.with_grouped_weights_decompression = false;

--- a/src/cpu/x64/jit_brgemm_weights_decompression_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_weights_decompression_kernel.cpp
@@ -79,6 +79,11 @@ void jit_brgemm_weights_decompression_kernel_t<isa>::load_weights(Vmm vmm_load, 
             uni_vcvtdq2ps(vmm_load, vmm_load);
             break;
         }
+        case data_type::s8: {
+            uni_vpmovsxbd(vmm_load, addr);
+            uni_vcvtdq2ps(vmm_load, vmm_load);
+            break;
+        }
         case data_type::u4: {
             uni_vpmovzxbd(vmm_load, addr);
             if (ic % 2 == 0) {
@@ -227,7 +232,7 @@ void jit_brgemm_weights_decompression_kernel_t<isa>::generate() {
             for (size_t ocb = 0; ocb < oc_blocks_num; ocb++) {
                 for (size_t ic = 0; ic < jcp_.ic_internal_size; ic++) {
                     size_t weights_offset;
-                    if (jcp_.weights_dt == data_type::u8)
+                    if (jcp_.weights_dt == data_type::u8 || jcp_.weights_dt == data_type::s8)
                         weights_offset = (ic * jcp_.oc_size + ocb * vec_size) * weights_dt_size / typesize_scale;
                     else
                         weights_offset = ocb * jcp_.ic_internal_size * vec_size * weights_dt_size / typesize_scale;


### PR DESCRIPTION
# Description

Inner-product with symmetrically quantized/compressed weight may have s8 as weight data type (it saves the zero-point subtraction cost), this change added support to such weight dt.

Fixes # (github issue)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/oneapi-src/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/oneapi-src/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
