### PR TITLE
[RISCV64] Fixed build

### DIFF
--- a/src/cpu/rv64/rvv_nchw_pooling.hpp
+++ b/src/cpu/rv64/rvv_nchw_pooling.hpp
@@ -19,6 +19,7 @@
 #define RV64_NCHW_POOLING_HPP
 
 #include "cpu/cpu_pooling_pd.hpp"
+#include "common/primitive.hpp"
 
 namespace dnnl {
 namespace impl {


### PR DESCRIPTION
Missed include `primitive.hpp`