### PR TITLE
[FORK][FIX][x64] Fixed need_mask_register for eltwise injectors

### DIFF
--- a/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
@@ -1998,6 +1998,9 @@ bool jit_uni_eltwise_injector_f32<isa, Wmm>::need_mask_register(
             case eltwise_round: return false;
             case eltwise_hardswish: return false;
             case eltwise_hardsigmoid: return false;
+            case eltwise_hsigmoid: return false;
+            case eltwise_round_half_to_even: return false;
+            case eltwise_round_half_away_from_zero: return true;
             default: assert(!"unsupported eltwise algorithm");
         }
     } else {


### PR DESCRIPTION
Added missed eltwise alg types in `jit_uni_eltwise_injector_f32::need_mask_register`

PR in OpenVINO: https://github.com/openvinotoolkit/openvino/pull/26232