### PR TITLE
[RV64] Added compilation check for overloaded intrinsics

### DIFF
--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -419,7 +419,10 @@ if (DNNL_TARGET_ARCH STREQUAL "RV64")
     # Check if the RVV Intrinsics can be compiled with the current toolchain and flags
     include(CheckCXXSourceCompiles)
     check_cxx_source_compiles("#include <riscv_vector.h>
-                               int main() { return 0; };"
+                               int main() { 
+                                size_t size = 64;
+                                return vsetvl_e32m2(size); 
+                               };"
                                CAN_COMPILE_RVV_INTRINSICS
     )
     # set CAN_COMPILE_RVV_INTRINSICS to TRUE / FALSE instead of 1 / "" (Undefined)


### PR DESCRIPTION
Added smarter compilation check for riscv64 build.

The current check verifies only `#include <riscv_vector.h>` - there are RVV. The current implementation of `MaxPooling` uses intrinsics without `__riscv64` prefix. But there is ratified ISA `V` for vector intrinsics with format `__riscv64`. The compiler Clang, LLVM provides overloaded intrinsics (without `__riscv64`). But, GCC doesn't.
Because of that modern GCC compiler with RVV support cannot compile MaxPooling primitive on riscv64 platforms.

The PR adds intrinsic `vsetvl_e32m2` without the prefix to verify that the current compiler can work with this mnemonics.

