### PR TITLE
Fixed issue with installed multiple version of the OpenCL

### DIFF
--- a/cmake/FindOpenCL.cmake
+++ b/cmake/FindOpenCL.cmake
@@ -47,18 +47,18 @@ function(_FIND_OPENCL_VERSION)
   set(CMAKE_REQUIRED_QUIET ${OpenCL_FIND_QUIETLY})
 
   CMAKE_PUSH_CHECK_STATE()
-  foreach(VERSION "2_2" "2_1" "2_0" "1_2" "1_1" "1_0")
+  foreach(VERSION "3_0" "2_2" "2_1" "2_0" "1_2" "1_1" "1_0")
     set(CMAKE_REQUIRED_INCLUDES "${OpenCL_INCLUDE_DIR}")
 
     if(APPLE)
       CHECK_SYMBOL_EXISTS(
         CL_VERSION_${VERSION}
-        "${OpenCL_INCLUDE_DIR}/Headers/cl.h"
+        "Headers/cl.h"
         OPENCL_VERSION_${VERSION})
     else()
       CHECK_SYMBOL_EXISTS(
         CL_VERSION_${VERSION}
-        "${OpenCL_INCLUDE_DIR}/CL/cl.h"
+        "CL/cl.h"
         OPENCL_VERSION_${VERSION})
     endif()
 


### PR DESCRIPTION
# Description
This PR fix issue with multiple version OpenCL installed on machine as well as brings new versions of OpenCL 3_0

For details explanation of an issue with `${OPENCL_INCLUDE_DIR}/CL/cl.h` https://stackoverflow.com/a/79347124/5157245

Similar PR was already merged in https://github.com/oneapi-src/oneDNN/pull/2378 and https://gitlab.kitware.com/cmake/cmake/-/merge_requests/10366, issue was more deeply investigated and PR was reworked