### PR TITLE
Backport: cpu: x64: conv: disable zp with large zp buffer on AMX

### DIFF
--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2024 Intel Corporation
+* Copyright 2020-2025 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -2393,6 +2393,12 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                     || !IMPLICATION(jcp.dst_zero_point || jcp.src_zero_point,
                             is_int8_convolution)),
             VERBOSE_UNSUPPORTED_ZP_CFG);
+
+    // Dispatch the shapes to VNNI for better performance
+    const bool req_zp_large_buffer = jcp.src_zero_point
+            && jcp.oc * jcp.ow > 8192 && (jcp.r_pad > 0 || jcp.l_pad > 0);
+    VDISPATCH_CONV_IC(!req_zp_large_buffer, VERBOSE_IMPL_HEURISTIC_FAIL,
+            "no optimization for zero point on AMX");
 
     // Calculate zero-point padding values outside of the main JIT-kernel
     // and store the results in an auxiliary buffer.

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -2340,6 +2340,14 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             * comp_buffer_ow * jcp.oc_block;
     jcp.s8s8_comp_buffer_size = jcp.comp_a_buffer_size;
 
+    // Dispatch the shapes to VNNI for better performance
+    // TODO: optimize the perf for zero point with large buffer on AMX
+    if (is_amx(isa) && jcp.src_zero_point && jcp.exec_type == exec_trans
+            && (jcp.l_pad > 0 || jcp.r_pad > 0) && jcp.oc * jcp.ow > 8192)
+        VDISPATCH_CONV_IC(!allow_perf_heuristics(jcp),
+                VERBOSE_IMPL_HEURISTIC_FAIL,
+                "no optimization for zero point on amx")
+
     // For padding shapes, we calculate the comp along with the computation
     // inside brgemm kernel when output size is small to get optimal perf
     // For shapes with large ow we calculate the comp inside brgemm kernel too


### PR DESCRIPTION
# Description

Cherry-pick ONEDNN stock 3.6 fix 

### Bug fixes
https://jira.devtools.intel.com/browse/CVS-156500



