### PR TITLE
[FORK][FEATURE] Add jit debug trace log dump in GCC debug mode for aarch64

### DIFF
--- a/src/cpu/aarch64/jit_generator.hpp
+++ b/src/cpu/aarch64/jit_generator.hpp
@@ -681,7 +681,31 @@ public:
     virtual const char *name() const = 0;
     virtual const char *source_file() const = 0;
 
+    void dump_debug_traces(const uint8_t *code, size_t code_size) const {
+#if !defined(NDEBUG) && defined(__GNUC__)
+        if (code && get_jit_dump()) {
+        #define MAX_FNAME_LEN 256
+            static int counter = 0;
+            char fname[MAX_FNAME_LEN + 1];
+            snprintf(fname, MAX_FNAME_LEN, "dnnl_traces_cpu_%s.%d.txt", name(),
+                    counter);
+            counter++;
+
+            std::cout << "[ oneDNN ] dump_debug_traces: " << fname << std::endl;
+            FILE *fp = fopen(fname, "wb+");
+            if (fp) {
+                for (const auto & p : get_debug_traces()) {
+                    fprintf(fp, "%lx:\t%s\n", p.first, p.second.c_str());
+                }
+                fclose(fp);
+            }
+        #undef MAX_FNAME_LEN
+        }
+#endif
+    }
+
     void register_jit_code(const uint8_t *code, size_t code_size) const {
+        dump_debug_traces(code, code_size);
         jit_utils::register_jit_code(code, code_size, name(), source_file());
     }
 

--- a/third_party/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64.h
+++ b/third_party/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64.h
@@ -69,6 +69,13 @@
 #endif
 #endif
 
+// for debug trace in GCC
+#include <map>
+#if !defined(NDEBUG) && defined(__GNUC__) && !(defined(__ANDROID__) || defined(ANDROID))
+#include <execinfo.h>
+#include <sstream>
+#endif
+
 #include "xbyak_aarch64_err.h"
 
 namespace Xbyak_aarch64 {


### PR DESCRIPTION
JIT tracer implementation is based on the one already integrated in x86 xbyak: https://github.com/openvinotoolkit/oneDNN/commit/e56978cfe936a1323778d52993c18d752c892c2a