### PR TITLE
[FORK][FIX] Fix performance issues caused by using the thread pool

### DIFF
--- a/src/cpu/matmul/cpu_matmul_list.cpp
+++ b/src/cpu/matmul/cpu_matmul_list.cpp
@@ -95,11 +95,11 @@ const impl_list_item_t impl_list[] = REG_MATMUL_P({
         CPU_INSTANCE_AVX512(brgemm_matmul_t,avx512_core)
         CPU_INSTANCE_AVX2(brgemm_matmul_t,avx2_vnni_2)
         CPU_INSTANCE_AVX2(brgemm_matmul_t,avx2_vnni)
+        CPU_INSTANCE_AVX2(brgemm_matmul_t, avx2)
         CPU_INSTANCE(gemm_f32_matmul_t)
         CPU_INSTANCE(gemm_bf16_matmul_t, f32)
         CPU_INSTANCE(gemm_bf16_matmul_t, bf16)
         CPU_INSTANCE(gemm_x8s8s32x_matmul_t)
-        CPU_INSTANCE_AVX2(brgemm_matmul_t, avx2)
         CPU_INSTANCE(ref_matmul_t)
         CPU_INSTANCE(ref_matmul_int8_t)
         // These implementations are enabled only when DNNL_EXPERIMENTAL_SPARSE

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -2296,10 +2296,6 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
 
     if (try_exec_type_res == false) return status::unimplemented;
 
-#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
-    adjust_nthr(jcp, src_d, dst_d);
-#endif
-
     // ============ end blocking ===========================================
     jcp.brg_type
             = (jcp.use_uker && one_of(jcp.exec_type, exec_base, exec_trans))
@@ -2529,10 +2525,6 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         if (cur_brgb.eff > best_brgb.eff) best_brgb = cur_brgb;
     }
     best_brgb.save_to_jcp(jcp);
-
-#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
-    adjust_nthr(jcp, src_d, dst_d);
-#endif
 
     // =============== end blocking =================================
 


### PR DESCRIPTION
# Description

Performance drop when setting parallel to TBB STATIC partitioner through by thread pool.

Fixes # (github issue)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/uxlfoundation/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/uxlfoundation/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
