### PR TITLE
[FORK][ARM] Update minimum ACL version to 52.0.0

### DIFF
--- a/.github/automation/aarch64/ci.json
+++ b/.github/automation/aarch64/ci.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
-        "acl": "v25.02",
+        "acl": "v52.0.0",
         "gcc": "13",
         "clang": "17",
         "onednn-base": "v3.7"

--- a/.github/automation/aarch64/get_acl.sh
+++ b/.github/automation/aarch64/get_acl.sh
@@ -25,7 +25,7 @@ echo "github workspace $GITHUB_WORKSPACE"
 os_type=$(uname)
 
 ACL_WITH_ASSERTS=${ACL_WITH_ASSERTS:-0}
-ACL_VERSION=${ACL_VERSION:-v24.08.1}
+ACL_VERSION=${ACL_VERSION:-v52.0.0}
 
 if [[ "$os_type" == "Linux" ]]; then
   echo "This machine is running Linux"
@@ -91,5 +91,3 @@ ACL_LIB_DIR=$(find_acl_lib_dir)
 echo "Using ACL lib from ${ACL_LIB_DIR}"
 echo "cp contents from ${ACL_LIB_DIR} to ${ACL_ROOT_DIR}/lib"
 cp -rf "$ACL_LIB_DIR"* "$ACL_ROOT_DIR/lib/"
-
-echo "${ACL_VERSION}" >"${ACL_ROOT_DIR}/arm_compute/arm_compute_version.embed"

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ On a CPU based on Arm AArch64 architecture, oneDNN CPU engine can be built with
 machine learning applications and provides AArch64 optimized implementations
 of core functions. This functionality currently requires that ACL is downloaded
 and built separately. See [Build from Source] section of the Developer Guide for
-details. oneDNN only supports Compute Library versions 24.11.1 or later.
+details. oneDNN only supports Compute Library version 52.
 
 [Arm Compute Library (ACL)]: https://github.com/arm-software/ComputeLibrary
 

--- a/cmake/ACL.cmake
+++ b/cmake/ACL.cmake
@@ -1,5 +1,5 @@
 # ******************************************************************************
-# Copyright 2020-2024 Arm Limited and affiliates.
+# Copyright 2020-2025 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,31 +31,62 @@ endif()
 
 find_package(ACL REQUIRED)
 
-set(ACL_MINIMUM_VERSION "24.11.1")
+# Required. The minimum compatible major-version as per Semantic Versioning.
+set(ACL_MIN_MAJOR_VERSION "52")
+
+# Optional. Maximum known compatible version if any.
+# Set to an empty-string if none.
+set(ACL_MAX_MAJOR_VERSION "")
 
 if(ACL_FOUND)
     file(GLOB_RECURSE ACL_VERSION_FILE ${ACL_INCLUDE_DIR}/*/arm_compute_version.embed)
     if ("${ACL_VERSION_FILE}" STREQUAL "")
         message(WARNING
             "Build may fail. Could not determine ACL version.\n"
-            "Supported ACL versions:\n"
-            "- minimum required is ${ACL_MINIMUM_VERSION}\n"
+            "File 'arm_compute_version.embed' not found in ${ACL_INCLUDE_DIR}/**\n"
+            "Minimum compatible ACL version is ${ACL_MIN_MAJOR_VERSION}\n"
         )
     else()
         file(READ ${ACL_VERSION_FILE} ACL_VERSION_STRING)
-        string(REGEX MATCH "v([0-9]+\\.[0-9]+\\.?[0-9]*)" ACL_VERSION "${ACL_VERSION_STRING}")
-        set(ACL_VERSION "${CMAKE_MATCH_1}")
-        if ("${ACL_VERSION}" VERSION_EQUAL "0.0")
-            # Unreleased ACL versions come with version string "v0.0-unreleased", and may not be compatible with oneDNN.
-            # It is recommended to use the latest release of ACL.
+
+        if("${ACL_VERSION_STRING}" MATCHES "arm_compute_version=v([0-9]+)\\.([0-9]+)\\.?([0-9]*)")
+            set(ACL_MAJOR_VERSION "${CMAKE_MATCH_1}")
+            set(ACL_MINOR_VERSION "${CMAKE_MATCH_2}")
+
+            if ("${ACL_MAJOR_VERSION}.${ACL_MINOR_VERSION}" VERSION_EQUAL "0.0")
+                # Unreleased ACL versions come with version string "v0.0-unreleased", and may not be compatible with oneDNN.
+                # It is recommended to use a supported major-version of ACL.
+                message(WARNING
+                    "Build may fail. Using an unreleased ACL version.\n"
+                    "Minimum compatible ACL version is ${ACL_MIN_MAJOR_VERSION}\n"
+                )
+            elseif("${ACL_MAJOR_VERSION}" LESS "${ACL_MIN_MAJOR_VERSION}")
+                message(FATAL_ERROR
+                    "Detected ACL version ${ACL_MAJOR_VERSION}, but minimum "
+                    "compatible is ${ACL_MIN_MAJOR_VERSION}\n"
+                )
+            elseif("${ACL_MAJOR_VERSION}" GREATER "${ACL_MIN_MAJOR_VERSION}")
+                # This is not necessarily an error. Need to check if there is a
+                # known incompatible maximum version:
+                if("${ACL_MAX_MAJOR_VERSION}" STREQUAL "")
+                    message(WARNING
+                        "Build may fail. Using a newer ACL version than officially supported.\n"
+                        "Detected ACL version ${ACL_MAJOR_VERSION}, but "
+                        "supported version is ${ACL_MIN_MAJOR_VERSION}\n"
+                    )
+                else()
+                    if("${ACL_MAJOR_VERSION}" GREATER "${ACL_MAX_MAJOR_VERSION}")
+                    message(FATAL_ERROR
+                        "Detected ACL version ${ACL_MAJOR_VERSION}, but maximum "
+                        "compatible version is ${ACL_MAX_MAJOR_VERSION}\n"
+                    )
+                    endif()
+                endif()
+            endif()
+        else()
             message(WARNING
-                "Build may fail. Using unreleased ACL version.\n"
-                "Supported ACL versions:\n"
-                "- minimum required is ${ACL_MINIMUM_VERSION}\n"
-            )
-        elseif("${ACL_VERSION}" VERSION_LESS "${ACL_MINIMUM_VERSION}")
-            message(FATAL_ERROR
-                "Detected ACL version ${ACL_VERSION}, but minimum required is ${ACL_MINIMUM_VERSION}\n"
+                "Build may fail. Could not determine ACL version.\n"
+                "Unexpected version string format in ${ACL_VERSION_FILE}.\n"
             )
         endif()
     endif()

--- a/src/cpu/acl/matmul/acl_matmul.cpp
+++ b/src/cpu/acl/matmul/acl_matmul.cpp
@@ -178,11 +178,9 @@ status_t acl_matmul_t::execute_forward(const exec_ctx_t &ctx) const {
 
     std::unique_lock<std::mutex> locker {mtx_, std::defer_lock};
 
-    // Some of the underlying kernels used by ACL still require some state and
-    // are not safe to be called in parallel with different execution contexts.
-    // Eventually when all kernels are truly stateless, this guard can be
-    // removed.
-    if (!acl_obj_->asm_gemm.has_stateless_impl()) { locker.lock(); }
+    // Non-fixed-format kernels in ACL hold shared state and are not safe to be
+    // called in parallel with different execution contexts.
+    if (!IsFixedFormat) { locker.lock(); }
 
     bool is_transA = amp.is_transA;
     bool is_transB = amp.is_transB;


### PR DESCRIPTION
The commit https://github.com/uxlfoundation/oneDNN/commit/8c68c00247971ec96c45388b70f45f3feec17ca4 needs to be propagated to OpenVINO fork because it's needed to use non-fixed-format kernels in ACL.