### PR TITLE
Fix for Conv-DWConv-PRelu fusing

### DIFF
--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32_old.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32_old.cpp
@@ -397,6 +397,10 @@ void jit_avx2_1x1_conv_kernel_f32_old::generate() {
 
     std::size_t post_ops_pointers_count = 0;
     for (int i = 0; i < p.len(); i++) {
+        if (jcp.with_dw_conv && p.entry_[i].is_convolution()) {
+            // dw_conv and post_ops after it are handled externally, so skip them
+            break;
+        }
         if (p.entry_[i].is_depthwise() || p.entry_[i].is_quantization()) {
             post_ops_pointers_count++;
         }

--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32_old.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32_old.cpp
@@ -398,7 +398,7 @@ void jit_avx2_1x1_conv_kernel_f32_old::generate() {
     std::size_t post_ops_pointers_count = 0;
     for (int i = 0; i < p.len(); i++) {
         if (jcp.with_dw_conv && p.entry_[i].is_convolution()) {
-            // dw_conv and post_ops after it are handled externally, so skip them
+            // dw_conv and post_ops after it are handled externally in *dw_conv* kernels, so skip them here.
             break;
         }
         if (p.entry_[i].is_depthwise() || p.entry_[i].is_quantization()) {
@@ -606,7 +606,7 @@ status_t jit_avx2_1x1_conv_kernel_f32_old::init_conf(jit_1x1_conv_conf_t &jcp,
         return status::unimplemented;
 
     if (jcp.with_dw_conv) {
-        // dw_conv and post_ops after it are handled externally, so skip them
+        // dw_conv and post_ops after it are handled externally in *dw_conv* kernels, so skip them here.
         jcp.post_ops.entry_.assign(p.entry_.cbegin(),
                                    p.entry_.cbegin() + dw_conv_ind);
 


### PR DESCRIPTION
**Details:**
Kernel `jit_avx2_1x1_conv_kernel_f32_old` skips DW Convolution post-op on initialization step, but tries to add it on the code generation step. This fix aligns behavior.
OV PR: https://github.com/openvinotoolkit/openvino/pull/33917

**Ticket:**
173761