### PR TITLE
Revert "cpu: x64: matmul: add missing VDISPATCH_REORDER_IC check"

### DIFF
--- a/src/cpu/x64/matmul/brgemm_matmul_reorders.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_reorders.cpp
@@ -79,12 +79,10 @@ status_t calculate_plain_transpose_blocks(dim_t &batch, dim_t &M, dim_t &K,
     }
 
     memory_desc_t src_md_reduced, dst_md_reduced;
-    VDISPATCH_REORDER_IC(memory_desc_reshape(src_md_reduced, src_md,
-                                 non_unit_dim, non_unit_dims),
-            VERBOSE_UNSUPPORTED_TENSOR_LAYOUT, "src");
-    VDISPATCH_REORDER_IC(memory_desc_reshape(dst_md_reduced, dst_md,
-                                 non_unit_dim, non_unit_dims),
-            VERBOSE_UNSUPPORTED_TENSOR_LAYOUT, "dst");
+    CHECK(memory_desc_reshape(
+            src_md_reduced, src_md, non_unit_dim, non_unit_dims));
+    CHECK(memory_desc_reshape(
+            dst_md_reduced, dst_md, non_unit_dim, non_unit_dims));
 
     const memory_desc_wrapper id(src_md_reduced), od(dst_md_reduced);
 


### PR DESCRIPTION
This reverts commit 5f9c218287e27dce2c81370e3b9b566bdaa8c78f.

# Description

Please include a summary of the change. Please also include relevant motivation and context. See [contribution guidelines](https://github.com/uxlfoundation/oneDNN/blob/main/CONTRIBUTING.md) for more details. If the change fixes an issue not documented in the project's Github issue tracker, please document all steps necessary to reproduce it.

Fixes # (github issue)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/uxlfoundation/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/uxlfoundation/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
