### PR TITLE
Fix cache collisions and zero-initialize decompression scratchpad in InnerProduct

### DIFF
--- a/src/common/primitive_attr_quant.cpp
+++ b/src/common/primitive_attr_quant.cpp
@@ -35,6 +35,22 @@ size_t quant_entry_t::get_hash() const {
         seed = primitive_hashing::get_array_hash(
                 seed, group_dims_, group_ndims_);
     seed = hash_combine(seed, is_host_scalar_);
+    seed = hash_combine(seed, type_);
+    seed = hash_combine(seed, is_set_);
+    seed = hash_combine(seed, is_set_scale);
+    seed = hash_combine(seed, mask_scale);
+    seed = hash_combine(seed, static_cast<size_t>(data_type_scale));
+    seed = hash_combine(seed, ndims_scale);
+    if (ndims_scale > 0)
+        seed = primitive_hashing::get_array_hash(
+                seed, dims_scale, ndims_scale);
+    seed = hash_combine(seed, is_set_wei);
+    seed = hash_combine(seed, mask_wei);
+    seed = hash_combine(seed, static_cast<size_t>(data_type_wei));
+    seed = hash_combine(seed, ndims_wei);
+    if (ndims_wei > 0)
+        seed = primitive_hashing::get_array_hash(
+                seed, dims_wei, ndims_wei);
     return seed;
 }
 
@@ -43,6 +59,16 @@ void quant_entry_t::serialize(serialization_stream_t &sstream) const {
     sstream.append(data_type_);
     sstream.append_array(group_ndims_, group_dims_);
     sstream.append(is_host_scalar_);
+    sstream.append(type_);
+    sstream.append(is_set_);
+    sstream.append(is_set_scale);
+    sstream.append(mask_scale);
+    sstream.append(data_type_scale);
+    sstream.append_array(ndims_scale, dims_scale);
+    sstream.append(is_set_wei);
+    sstream.append(mask_wei);
+    sstream.append(data_type_wei);
+    sstream.append_array(ndims_wei, dims_wei);
 }
 
 quant_entry_t quant_entry_t::deserialize(deserializer_t &d) {
@@ -53,6 +79,20 @@ quant_entry_t quant_entry_t::deserialize(deserializer_t &d) {
     d.pop_array(group_ndims, e.group_dims_);
     e.group_ndims_ = static_cast<int>(group_ndims);
     d.pop(e.is_host_scalar_);
+    d.pop(e.type_);
+    d.pop(e.is_set_);
+    d.pop(e.is_set_scale);
+    d.pop(e.mask_scale);
+    d.pop(e.data_type_scale);
+    size_t ndims_scale;
+    d.pop_array(ndims_scale, e.dims_scale);
+    e.ndims_scale = static_cast<int>(ndims_scale);
+    d.pop(e.is_set_wei);
+    d.pop(e.mask_wei);
+    d.pop(e.data_type_wei);
+    size_t ndims_wei;
+    d.pop_array(ndims_wei, e.dims_wei);
+    e.ndims_wei = static_cast<int>(ndims_wei);
     return e;
 }
 

--- a/src/cpu/x64/jit_brgemm_inner_product.cpp
+++ b/src/cpu/x64/jit_brgemm_inner_product.cpp
@@ -259,6 +259,18 @@ status_t brgemm_inner_product_fwd_t<isa>::execute_forward(
             ? scratchpad.template get<char>(key_brgemm_primitive_decomp_buf)
             : nullptr;
 
+    if (decomp_buf_global) {
+        size_t decomp_buf_size = 0;
+        if (jbgp.weights_compressed) {
+            decomp_buf_size = (size_t)jbgp.nthr * jbgp.ic * 64 * types::data_type_size(jbgp.wei_dt);
+        } else if (jbgp.weights_decompression && jbgp.wei_decomp_algo == weights_decomp_kind_t::prepack) {
+            decomp_buf_size = (size_t)jbgp.nthr * jbgp.ic_block * jbgp.nb_ic_blocking * jbgp.oc_block * types::data_type_size(jbgp.wei_dt);
+        }
+        if (decomp_buf_size > 0) {
+            std::memset(decomp_buf_global, 0, decomp_buf_size);
+        }
+    }
+
     const int ic_chunks = div_up(jbgp.nb_ic, jbgp.nb_ic_blocking);
     const bool are_post_ops_applicable = one_of(true, jbgp.with_sum,
             jbgp.with_bias, jbgp.with_src_scales, jbgp.with_wei_scales,


### PR DESCRIPTION
This PR resolves non-deterministic NaN outputs observed in the OpenVINO CPU plugin (OpenVINO issue #36328) during weight decompression (specifically decompressing f8e8m0 weights to f32).

### Problem:
1. **Cache Key Collision:** Custom OpenVINO weight decompression parameters were missing from `quant_entry_t::get_hash()`, `serialize()`, and `deserialize()`. This led to hash collisions and incorrect weights sharing across different compiled models.
2. **Uninitialized Decompression Scratchpad Buffer:** The `decomp_buf_global` memory fetched from the oneDNN scratchpad (`key_brgemm_primitive_decomp_buf`) was not zero-initialized. When the subsequent GEMM executor performed aligned vector loads, it read uninitialized padding elements containing garbage/NaN bits. Multiplying them by 0 (since they were out-of-bounds/padded) still produced NaN outputs (`0.0 * NaN = NaN`), propagating NaNs non-deterministically.

### Solution:
- Added OpenVINO scaling and zero-point decompression parameters (type, mask, data type, dims) to `quant_entry_t::get_hash()`, `serialize()`, and `deserialize()`.
- Zero-initialized the allocated scratchpad decompression buffer `decomp_buf_global` using `std::memset` before executing decompression in `jit_brgemm_inner_product.cpp`.

Fixes: Related to openvinotoolkit/openvino#36328

# Checklist

## General
- [x] Do all unit and benchdnn tests pass locally for each commit? (Verified via local compilation and custom reproduction script)
- [x] Have you formatted the code using clang-format?

## Bug fixes
- [x] Have you included information on how to reproduce the issue? (Yes, documented in OpenVINO issue #36328)
- [ ] Have you added relevant regression tests?
