### PR TITLE
ci: riscv: partition tests and add timeouts for QEMU stability

### DIFF
--- a/.github/automation/riscv/test.sh
+++ b/.github/automation/riscv/test.sh
@@ -349,8 +349,16 @@ echo "Using QEMU for test execution"
 export QEMU_LD_PREFIX=/usr/riscv64-linux-gnu
 
 if [[ "$ONEDNN_TEST_SET" == "SMOKE" ]]; then
+    skipped_tests=$("${SCRIPT_DIR}"/skipped-tests.sh)
+    start=${ONEDNN_TEST_PART:-1}
+    stride=${ONEDNN_TEST_STRIDE:-1}
+    # Per-test timeout: SMOKE tests run in seconds under QEMU, so a generous
+    # cap turns a hung test (e.g. an RVV codepath that loops forever) into a
+    # fast, named failure instead of a silent multi-hour job stall.
+    timeout=${ONEDNN_TEST_TIMEOUT:-600}
     set -x
-    ctest --no-tests=error --output-on-failure -E "$("${SCRIPT_DIR}"/skipped-tests.sh)"
+    ctest --no-tests=error --output-on-failure --timeout "${timeout}" \
+            -I "${start},,${stride}" -E "${skipped_tests}"
     set +x
 
 elif [[ "$ONEDNN_TEST_SET" == "CI" ]]; then

--- a/.github/workflows/ci-riscv.yml
+++ b/.github/workflows/ci-riscv.yml
@@ -133,15 +133,25 @@ jobs:
   test:
     needs: build
     strategy:
-      fail-fast: true
+      # Keep vlen128/vlen256 (and their partitions) independent so one flaky
+      # QEMU run does not cancel the others.
+      fail-fast: false
       matrix:
         config: [
           { name: riscv-test-vlen128, threading: OMP, testset: SMOKE, vlen: 128, build: RelWithAssert },
           { name: riscv-test-vlen256, threading: OMP, testset: SMOKE, vlen: 256, build: RelWithAssert }
         ]
+        # Split each vlen config across parallel partitions to cut wall-clock
+        # under slow QEMU emulation. Stride partitioning (ctest -I start,,stride)
+        # needs no cost table and covers every test exactly once.
+        part: [1, 2, 3, 4]
+        parts: [4]
 
-    name: ${{ matrix.config.name }}, ${{ matrix.config.threading }}
+    name: ${{ matrix.config.name }} (${{ matrix.part }}/${{ matrix.parts }}), ${{ matrix.config.threading }}
     runs-on: ubuntu-24.04
+    # vlen128 completes in ~17 min; cap well above that so a hung QEMU run is
+    # killed promptly instead of stalling until the 6 h default.
+    timeout-minutes: 40
     steps:
       - name: Checkout oneDNN
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -183,6 +193,8 @@ jobs:
           CTEST_PARALLEL_LEVEL: 4
           ONEDNN_THREADING: ${{ matrix.config.threading }}
           ONEDNN_TEST_SET: ${{ matrix.config.testset }}
+          ONEDNN_TEST_PART: ${{ matrix.part }}
+          ONEDNN_TEST_STRIDE: ${{ matrix.parts }}
           QEMU_CPU: "rv64,v=true,vlen=${{ matrix.config.vlen }},vext_spec=v1.0"
 
   status:


### PR DESCRIPTION
## Motivation

The RISC-V CI runs the test suite under **QEMU user-mode emulation**, which is ~10-50x slower than native. The `vlen256` job occasionally hangs: in one recent run it ran ~58 min and the `Run oneDNN tests` step produced **no output at all** before the job died, giving zero diagnostic signal. Normal runs finish in ~17 min (181 tests), so this is a transient QEMU/runner stall rather than a real test failure — but the silent multi-hour hang and the lack of a per-test cap make it hard to diagnose and slow to fail.

This is a RISC-V CI robustness change only — no library code is touched.

## Changes

**`.github/workflows/ci-riscv.yml`**
- `fail-fast: false` on the `test` matrix so a flaky `vlen128`/`vlen256` run (or one partition) no longer cancels the siblings.
- `timeout-minutes: 40` on the `test` job — a hung QEMU run is now killed promptly instead of stalling toward the 6 h default.
- Split each `vlen` config across **4 parallel partitions** via a `part`/`parts` matrix dimension (2 vlen × 4 = 8 jobs). Wall-clock per partition drops ~linearly.

**`.github/automation/riscv/test.sh`** (SMOKE branch)
- Apply stride partitioning `ctest -I ${start},,${stride}` driven by `ONEDNN_TEST_PART`/`ONEDNN_TEST_STRIDE`. This mirrors the partitioning the `CI` testset branch already uses; stride needs no cost table and covers every test **exactly once** (verified: N=181 → 46/45/45/45, no gaps, no overlaps).
- Add `--timeout ${ONEDNN_TEST_TIMEOUT:-600}` so a hung test (e.g. an RVV codepath that loops forever) fails fast **with its name** instead of stalling the whole job. SMOKE tests run in seconds, so 600 s is a generous cap. The cap is scoped to the SMOKE branch only and does not affect the weekly `CI` testset (which has multi-hour tests).

## Notes
- Defaults preserve old behavior when the env vars are unset (`start=1`, `stride=1` → all tests, single partition).