### PR TITLE
Add API dnnl_threadpool_interop_set_scratchpad_concurrency

### DIFF
--- a/include/oneapi/dnnl/dnnl_threadpool.h
+++ b/include/oneapi/dnnl/dnnl_threadpool.h
@@ -79,6 +79,26 @@ dnnl_status_t DNNL_API dnnl_threadpool_interop_set_max_concurrency(
 dnnl_status_t DNNL_API dnnl_threadpool_interop_get_max_concurrency(
         int *max_concurrency);
 
+/// Sets the maximum concurrency assumed by oneDNN when computing
+/// scratchpad sizes outside a parallel call.
+///
+/// @param max_concurrency The maximum scratchpad concurrency assumed by oneDNN
+/// when outside a parallel call. This is a threadlocal setting.
+/// @returns #dnnl_success on success and a status describing the
+/// error otherwise.
+dnnl_status_t DNNL_API dnnl_threadpool_interop_set_scratchpad_concurrency(
+        int max_concurrency);
+
+/// Gets the maximum concurrency assumed by oneDNN when computing
+/// scratchpad sizes outside a parallel call.
+///
+/// @param max_concurrency The maximum scratchpad concurrency assumed by oneDNN
+/// when outside a parallel call. This is a threadlocal setting.
+/// @returns #dnnl_success on success and a status describing the
+/// error otherwise.
+dnnl_status_t DNNL_API dnnl_threadpool_interop_get_scratchpad_concurrency(
+        int *max_concurrency);
+
 /// @copydoc dnnl_sgemm()
 /// @param threadpool A pointer to a threadpool interface (only when built with
 ///     the THREADPOOL CPU runtime).

--- a/src/common/dnnl_thread.hpp
+++ b/src/common/dnnl_thread.hpp
@@ -57,6 +57,9 @@
 inline int dnnl_get_max_threads() {
     return 1;
 }
+inline int dnnl_get_max_threads_for_scratchpad() {
+    return dnnl_get_max_threads();
+}
 inline int dnnl_in_parallel() {
     return 0;
 }
@@ -67,6 +70,9 @@ inline void dnnl_thr_barrier() {}
 #define DNNL_THR_SYNC 1
 inline int dnnl_get_max_threads() {
     return omp_get_max_threads();
+}
+inline int dnnl_get_max_threads_for_scratchpad() {
+    return dnnl_get_max_threads();
 }
 inline int dnnl_in_parallel() {
     return omp_in_parallel();
@@ -82,6 +88,9 @@ inline void dnnl_thr_barrier() {
 #define DNNL_THR_SYNC 0
 inline int dnnl_get_max_threads() {
     return tbb::this_task_arena::max_concurrency();
+}
+inline int dnnl_get_max_threads_for_scratchpad() {
+    return dnnl_get_max_threads();
 }
 inline int dnnl_in_parallel() {
     return 0;
@@ -119,8 +128,10 @@ dnnl::threadpool_interop::threadpool_iface *get_active_threadpool();
 
 // returns the maximum concurrency available in the given global context
 int get_max_concurrency();
+int get_scratchpad_concurrency();
 
 int &get_threadlocal_max_concurrency();
+int &get_threadlocal_scratchpad_concurrency();
 
 } // namespace threadpool_utils
 } // namespace impl
@@ -135,6 +146,15 @@ inline int dnnl_get_max_threads() {
 
     // Use the default max_concurrency only when no tp is passed by
     // user (e.g. primitive creation).
+    return tp ? std::max(1, tp->get_num_threads()) : max_concurrency;
+}
+inline int dnnl_get_max_threads_for_scratchpad() {
+    using namespace dnnl::impl::threadpool_utils;
+    dnnl::threadpool_interop::threadpool_iface *tp = get_active_threadpool();
+
+    int max_concurrency
+            = dnnl::impl::threadpool_utils::get_scratchpad_concurrency();
+
     return tp ? std::max(1, tp->get_num_threads()) : max_concurrency;
 }
 inline int dnnl_in_parallel() {

--- a/src/common/dnnl_thread.hpp
+++ b/src/common/dnnl_thread.hpp
@@ -152,8 +152,7 @@ inline int dnnl_get_max_threads_for_scratchpad() {
     using namespace dnnl::impl::threadpool_utils;
     dnnl::threadpool_interop::threadpool_iface *tp = get_active_threadpool();
 
-    int max_concurrency
-            = dnnl::impl::threadpool_utils::get_scratchpad_concurrency();
+    int max_concurrency = get_scratchpad_concurrency();
 
     return tp ? std::max(1, tp->get_num_threads()) : max_concurrency;
 }

--- a/src/common/dnnl_threadpool.cpp
+++ b/src/common/dnnl_threadpool.cpp
@@ -40,20 +40,20 @@ dnnl_status_t dnnl_threadpool_interop_get_max_concurrency(
 }
 
 dnnl_status_t dnnl_threadpool_interop_set_scratchpad_concurrency(
-    int max_concurrency) {
+        int max_concurrency) {
     using namespace dnnl::impl;
     threadpool_utils::get_threadlocal_scratchpad_concurrency()
-        = std::max(1, max_concurrency);
+            = std::max(1, max_concurrency);
     return status::success;
 }
 
 dnnl_status_t dnnl_threadpool_interop_get_scratchpad_concurrency(
-    int *max_concurrency) {
+        int *max_concurrency) {
     using namespace dnnl::impl;
     if (max_concurrency == nullptr) return status::invalid_arguments;
 
     *max_concurrency
-        = threadpool_utils::get_threadlocal_scratchpad_concurrency();
+            = threadpool_utils::get_threadlocal_scratchpad_concurrency();
     return status::success;
 }
 

--- a/src/common/dnnl_threadpool.cpp
+++ b/src/common/dnnl_threadpool.cpp
@@ -39,4 +39,22 @@ dnnl_status_t dnnl_threadpool_interop_get_max_concurrency(
     return status::success;
 }
 
+dnnl_status_t dnnl_threadpool_interop_set_scratchpad_concurrency(
+    int max_concurrency) {
+    using namespace dnnl::impl;
+    threadpool_utils::get_threadlocal_scratchpad_concurrency()
+        = std::max(1, max_concurrency);
+    return status::success;
+}
+
+dnnl_status_t dnnl_threadpool_interop_get_scratchpad_concurrency(
+    int *max_concurrency) {
+    using namespace dnnl::impl;
+    if (max_concurrency == nullptr) return status::invalid_arguments;
+
+    *max_concurrency
+        = threadpool_utils::get_threadlocal_scratchpad_concurrency();
+    return status::success;
+}
+
 #endif

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -443,8 +443,19 @@ int &get_threadlocal_max_concurrency() {
     return max_concurrency;
 }
 
+int &get_threadlocal_scratchpad_concurrency() {
+    thread_local int max_concurrency
+            = (int)cpu::platform::get_max_threads_to_use();
+    assert(max_concurrency > 0);
+    return max_concurrency;
+}
+
 int DNNL_API get_max_concurrency() {
     return get_threadlocal_max_concurrency();
+}
+
+int DNNL_API get_scratchpad_concurrency() {
+    return get_threadlocal_scratchpad_concurrency();
 }
 
 } // namespace threadpool_utils

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
@@ -147,7 +147,7 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::init(engine_t *engine) {
 
     CHECK(brgemm_convolution_bwd_utils::init_conf(jcp_, isa, desc_,
             diff_dst_md_, weights_md_, diff_src_md_, bias_md_, attr_,
-            dnnl_get_max_threads()));
+            dnnl_get_max_threads_for_scratchpad()));
 
     brgs_sz_ = 2 * 2 * 2 * 2;
     brgs_ = std::make_shared<brgemm_containers::brgemm_desc_container_t>();


### PR DESCRIPTION
# Description

## Problem
On CPU with adaptive threading, model load could fail in deconvolution descriptor creation because oneDNN reported a multi-GB scratchpad requirement for a single `ConvolutionBackpropData` node.

## Root Cause
This issue only happens with TBB_ADAPTIVE when the CPU partitioner runs in AUTO mode.
The CPU plugin calls `dnnl_threadpool_interop_set_max_concurrency(int max_concurrency)` to set the number of threads for oneDNN.
In partitioner=AUTO mode, max_concurrency=real worker-thread * 32. 
Some oneDNN primitives use the inflated virtual concurrency to decide implementation details and scratchpad size.
As a result, descriptors could be built against an inflated thread count, which amplified scratchpad requirements and caused large memory allocations.
**Simply put, oneDNN should use virtual concurrency to decide implementation details, and use real worker-thread to calculate scratchpad size.**

So this pull request introduces new functionality to control and query the maximum concurrency used by oneDNN when computing scratchpad sizes outside parallel calls. It adds thread-local APIs for setting and getting this "scratchpad concurrency," updates internal utilities to support the feature, and integrates the new API into convolution code paths that allocate scratchpad memory.

Fixes 
Fix compilation of small UNet crashes with 2026.0 and later on 16GB MTL
[CVS-187773](https://jira.devtools.intel.com/browse/CVS-187773)

Dependency PR: [PR#36435](https://github.com/openvinotoolkit/openvino/pull/36435)

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/uxlfoundation/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/uxlfoundation/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
