### PR TITLE
aarch64: Add explicit signed casts for MSVC compatibility

### DIFF
--- a/src/cpu/aarch64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/aarch64/jit_uni_binary_kernel.cpp
@@ -432,7 +432,7 @@ void jit_uni_binary_kernel_t<isa>::compute_bcast(bool tail) {
 
 template <cpu_isa_t isa>
 void jit_uni_binary_kernel_t<isa>::push(const Xbyak_aarch64::XReg &reg) {
-    str(reg, pre_ptr(X_SP, -(reg.getBit() / 8)));
+    str(reg, pre_ptr(X_SP, -static_cast<int>(reg.getBit() / 8)));
 }
 template <cpu_isa_t isa>
 void jit_uni_binary_kernel_t<isa>::pop(const Xbyak_aarch64::XReg &reg) {

--- a/src/cpu/aarch64/jit_uni_reorder.cpp
+++ b/src/cpu/aarch64/jit_uni_reorder.cpp
@@ -1599,7 +1599,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
             Label loop, if_no_tail, if_end;
 
             if (curr_node_has_tail) {
-                const size_t reg_bytes = X_TMP_0.getBit() / 8;
+                const int reg_bytes = static_cast<int>(X_TMP_0.getBit() / 8);
                 if (prb_.nodes[curr_node_id].is_parent_empty()) {
                     mov(reg_loop_cnt, tail_size);
                     // Put info that node is being processed with tail.


### PR DESCRIPTION
# Description

This PR fixes MSVC compilation issues in the AArch64 JIT code by introducing explicit signed integer casts before applying unary negation and using register-byte values as stack offsets.

## Motivation

While building OpenVINO for Windows on Arm64 using MSVC, compilation failed in oneDNN's AArch64 JIT code with the following errors:

```
src/cpu/aarch64/jit_uni_binary_kernel.cpp(435): error C4146:
unary minus operator applied to unsigned type, result still unsigned

src/cpu/aarch64/jit_uni_reorder.cpp(1607): error C4146:
unary minus operator applied to unsigned type, result still unsigned

src/cpu/aarch64/jit_uni_reorder.cpp(1463): warning C4267:
conversion from 'size_t' to 'int', possible loss of data
```
The issue occurs because `reg.getBit() / 8` returns a `size_t `(unsigned). Applying unary negation directly to this value causes MSVC to emit `C4146`, and using it where signed offsets are expected also produces conversion warnings.

## Fix

This change introduces explicit static_cast<int> conversions before applying unary negation and before storing register-byte values used as stack offsets. The resulting code compiles cleanly with MSVC while preserving the existing behaviour.

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/uxlfoundation/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/uxlfoundation/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
